### PR TITLE
feat(webrtc-client): WHEP client-config plugin (V1.3 /config.json API)

### DIFF
--- a/plugins/webrtc-client/engine/WebRtcClientModule.test.ts
+++ b/plugins/webrtc-client/engine/WebRtcClientModule.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { WebRtcClientModule } from './WebRtcClientModule.js';
+
+function createServices(instanceId = 'webrtc-client-test') {
+    return {
+        pipeWire: {} as any,
+        mediaRouter: {} as any,
+        processManager: {} as any,
+        deviceProviders: {} as any,
+        instanceId,
+    };
+}
+
+async function createModule(config: Record<string, unknown> = {}, instanceId?: string) {
+    const module = new WebRtcClientModule();
+    await module.onInit(config, createServices(instanceId));
+    return module;
+}
+
+// Track modules that bound the port so we always release it between tests.
+const started: WebRtcClientModule[] = [];
+afterEach(async () => {
+    while (started.length) {
+        const m = started.pop()!;
+        await m.onStop().catch(() => {});
+    }
+});
+
+async function start(module: WebRtcClientModule) {
+    started.push(module);
+    await module.onStart();
+    return module;
+}
+
+const CONFIG_URL = 'http://127.0.0.1:2000/config.json';
+
+describe('WebRtcClientModule', () => {
+    describe('buildPipeline', () => {
+        it('returns null — pure service module, no GStreamer pipeline', async () => {
+            const module = await createModule();
+            expect(module.buildPipeline({})).toBeNull();
+        });
+    });
+
+    describe('config mapping (/config.json shape)', () => {
+        it('maps clients to the V1.3 webRtcAudioStreams shape', async () => {
+            const module = await start(
+                await createModule({
+                    displayName: 'OCC Streams',
+                    clients: [
+                        { name: 'English', description: 'EN feed', url: 'https://mtx/whep/en', countryCode: 'gb' },
+                        { name: 'Zulu', description: 'ZU feed', url: 'https://mtx/whep/zu', countryCode: 'za' },
+                    ],
+                }),
+            );
+
+            const res = await fetch(CONFIG_URL);
+            expect(res.status).toBe(200);
+            expect(res.headers.get('content-type')).toContain('application/json');
+
+            const body = await res.json();
+            expect(body).toEqual({
+                displayName: 'OCC Streams',
+                webRtcAudioStreams: [
+                    { id: 'client-0', name: 'English', url: 'https://mtx/whep/en', countryCode: 'gb', note: 'EN feed' },
+                    { id: 'client-1', name: 'Zulu', url: 'https://mtx/whep/zu', countryCode: 'za', note: 'ZU feed' },
+                ],
+            });
+        });
+
+        it('defaults to the fallback title and an empty stream list', async () => {
+            const module = await start(await createModule({}));
+            const body = await (await fetch(CONFIG_URL)).json();
+            expect(body).toEqual({ displayName: 'Audio Streaming Service', webRtcAudioStreams: [] });
+        });
+
+        it('returns 404 for non-config paths', async () => {
+            await start(await createModule({}));
+            const res = await fetch('http://127.0.0.1:2000/');
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('lifecycle', () => {
+        it('binds on 127.0.0.1:2000 and reports running/ok', async () => {
+            const module = await start(await createModule({}));
+            const state = module.getState();
+            expect(state.running).toBe(true);
+            expect(state.health).toBe('ok');
+        });
+
+        it('closes the server on stop (connection refused afterwards)', async () => {
+            const module = await createModule({});
+            await module.onStart();
+            await module.onStop();
+            await expect(fetch(CONFIG_URL)).rejects.toBeDefined();
+            expect(module.getState().running).toBe(false);
+        });
+    });
+
+    describe('live config update', () => {
+        it('serves the new stream list without a restart', async () => {
+            const module = await start(await createModule({ clients: [] }));
+            expect((await (await fetch(CONFIG_URL)).json()).webRtcAudioStreams).toEqual([]);
+
+            await module.onLiveConfigUpdate({
+                clients: [{ name: 'New', description: '', url: 'https://mtx/whep/new', countryCode: 'us' }],
+            });
+
+            const body = await (await fetch(CONFIG_URL)).json();
+            expect(body.webRtcAudioStreams).toEqual([
+                { id: 'client-0', name: 'New', url: 'https://mtx/whep/new', countryCode: 'us', note: '' },
+            ]);
+        });
+    });
+
+    describe('single-instance / port-conflict handling', () => {
+        it('second binder errors without self-disabling (no selfStop); first stays healthy', async () => {
+            const first = await start(await createModule({}, 'webrtc-client-a'));
+
+            const second = await createModule({}, 'webrtc-client-b');
+            const selfStop = vi.fn();
+            second.on('selfStop', selfStop);
+            started.push(second);
+            await second.onStart();
+
+            // A port conflict (duplicate or foreign occupant) must NOT disable the
+            // module — it only errors and stays stopped.
+            expect(selfStop).not.toHaveBeenCalled();
+            expect(second.getState().health).toBe('error');
+            expect(second.getState().running).toBe(false);
+
+            // First instance is unaffected and keeps serving.
+            expect(first.getState().health).toBe('ok');
+            expect((await fetch(CONFIG_URL)).status).toBe(200);
+        });
+    });
+});

--- a/plugins/webrtc-client/engine/WebRtcClientModule.ts
+++ b/plugins/webrtc-client/engine/WebRtcClientModule.ts
@@ -1,0 +1,166 @@
+import http from 'node:http';
+import { GstPluginBase, type PipelineDescription, type ModuleServices } from '@media-router/engine';
+
+/** Internal-only bind — the config API must not be reachable from external devices. */
+const HOST = '127.0.0.1';
+const PORT = 2000;
+
+/** One configured WebRTC (WHEP) audio stream, as edited in the module settings. */
+interface WebRtcClient {
+    name: string;
+    description: string;
+    url: string;
+    countryCode: string;
+}
+
+/** The V1.3 `/config.json` document shape, consumed by media-router-audio-app. */
+interface WebRtcClientConfig {
+    displayName: string;
+    webRtcAudioStreams: Array<{
+        id: string;
+        name: string;
+        url: string;
+        countryCode: string;
+        note: string;
+    }>;
+}
+
+/**
+ * WebRTC (WHEP) client config publisher.
+ *
+ * Ports the V1.3 `WebRTCClient` control to V2: serves a JSON document describing
+ * the available WebRTC audio streams on an internal-only HTTP endpoint
+ * (`GET http://127.0.0.1:2000/config.json`). The media-router-audio-app project
+ * fetches this to render WHEP players for web clients.
+ *
+ * Media Router is NOT a WebRTC server — each client just carries the WHEP URL of
+ * an external server (e.g. MediaMTX).
+ *
+ * Pure service module: no GStreamer pipeline (`buildPipeline` → null), manages its
+ * own lifecycle like `n1-mixer`. The fixed port also bounds it to a single instance:
+ * if the port is already taken (a duplicate instance, or a foreign process) the
+ * module reports health=error and stays stopped — it does not self-disable.
+ */
+export class WebRtcClientModule extends GstPluginBase {
+    // Edits to the stream list / title apply live — the route reads `this.config`
+    // at request time, so the base-class default onLiveConfigUpdate (merge) suffices.
+    protected liveUpdatableParams: string[] = ['displayName', 'clients'];
+
+    private server: http.Server | null = null;
+
+    async onInit(config: Record<string, unknown>, services?: ModuleServices): Promise<void> {
+        await super.onInit(config, services);
+    }
+
+    /** Pure service — no GStreamer pipeline. */
+    buildPipeline(_config: Record<string, unknown>): PipelineDescription | null {
+        return null;
+    }
+
+    /** No audio ports. */
+    getPipeWireNodes(): { source?: string; sink?: string } {
+        return {};
+    }
+
+    /**
+     * Map the configured clients to the V1.3 `/config.json` shape. Field renames:
+     * `description` → `note`; `countryCode` passes through. Ids are index-based.
+     */
+    private buildConfig(): WebRtcClientConfig {
+        const clients = (this.config.clients as WebRtcClient[] | undefined) ?? [];
+        return {
+            displayName: (this.config.displayName as string) ?? 'Audio Streaming Service',
+            webRtcAudioStreams: clients.map((c, i) => ({
+                id: `client-${i}`,
+                name: c?.name ?? '',
+                url: c?.url ?? '',
+                countryCode: c?.countryCode ?? '',
+                note: c?.description ?? '',
+            })),
+        };
+    }
+
+    /**
+     * Start the internal config API. Does NOT call super.onStart() — this module
+     * runs an HTTP server instead of a GStreamer child process.
+     */
+    async onStart(): Promise<void> {
+        const server = http.createServer((req, res) => {
+            const path = (req.url ?? '').split('?')[0];
+            // No keep-alive: this endpoint is polled occasionally, and closing the
+            // socket per response avoids clients reusing a stale connection across
+            // a module restart (same fixed port).
+            if (req.method === 'GET' && path === '/config.json') {
+                const body = JSON.stringify(this.buildConfig());
+                res.writeHead(200, { 'content-type': 'application/json', connection: 'close' });
+                res.end(body);
+                return;
+            }
+            res.writeHead(404, { 'content-type': 'application/json', connection: 'close' });
+            res.end(JSON.stringify({ error: 'Not found' }));
+        });
+
+        server.on('error', (err: NodeJS.ErrnoException) => {
+            // Port already occupied — by a duplicate instance OR a foreign process.
+            // Report an error and stay stopped; do NOT self-disable. A foreign
+            // occupant must never permanently disable the module, and there is no
+            // auto-retry — a manual restart re-attempts the bind.
+            if (err.code === 'EADDRINUSE') {
+                this.server = null; // never bound — keep onStop from closing it
+                this.log.error({ port: PORT }, 'Port already in use — cannot start config API');
+                this.setHealth(
+                    'error',
+                    `Port ${PORT} already in use — another process or WebRTC Client Config instance owns it`,
+                );
+                return;
+            }
+            this.log.error({ err }, 'WebRTC client config server error');
+            this.setHealth('error', err.message);
+        });
+
+        this.server = server;
+
+        // Settle on either successful bind or bind failure — on failure the
+        // persistent 'error' handler above has already set health / self-stopped.
+        const listening = await new Promise<boolean>((resolve) => {
+            const onBindError = () => resolve(false);
+            server.once('error', onBindError);
+            server.listen(PORT, HOST, () => {
+                server.removeListener('error', onBindError);
+                resolve(true);
+            });
+        });
+
+        if (!listening) return;
+
+        this.running = true;
+        this.health = 'ok';
+        this.emit('stateChange', this.getState());
+        this.refreshStatus();
+
+        this.log.info({ host: HOST, port: PORT }, 'WebRTC client config API listening');
+    }
+
+    async onStop(): Promise<void> {
+        if (this.server) {
+            const server = this.server;
+            this.server = null;
+            await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
+        await super.onStop();
+    }
+
+    async onLiveConfigUpdate(changes: Record<string, unknown>): Promise<void> {
+        Object.assign(this.config, changes);
+        this.refreshStatus();
+    }
+
+    private refreshStatus(): void {
+        const clients = (this.config.clients as WebRtcClient[] | undefined) ?? [];
+        this.setStatusData('service', {
+            endpoint: `${HOST}:${PORT}/config.json`,
+            streamCount: clients.length,
+            status: 'Active',
+        });
+    }
+}

--- a/plugins/webrtc-client/package.json
+++ b/plugins/webrtc-client/package.json
@@ -1,0 +1,80 @@
+{
+    "name": "@media-router/plugin-webrtc-client",
+    "version": "2.0.0",
+    "private": true,
+    "description": "WebRTC (WHEP) client config — publishes stream details as JSON on 127.0.0.1:2000 for web-app clients",
+    "mediaRouter": {
+        "pluginId": "webrtc-client",
+        "displayName": "WebRTC Client Config",
+        "description": "Publishes a list of WebRTC (WHEP) audio streams as JSON on an internal-only port (127.0.0.1:2000) for the media-router-audio-app web clients. Media Router is NOT a WebRTC server — configure the WHEP URLs of your own server (e.g. MediaMTX).",
+        "color": "#6366f1",
+        "icon": "radio",
+        "category": "utility",
+        "architectures": [
+            "arm64",
+            "x86_64"
+        ],
+        "ports": [],
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string",
+                    "default": "Audio Streaming Service",
+                    "description": "Service title shown to web-app clients",
+                    "x-live": true
+                },
+                "clients": {
+                    "type": "array",
+                    "default": [],
+                    "description": "WebRTC (WHEP) audio streams",
+                    "x-live": true,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "default": "",
+                                "description": "Channel name"
+                            },
+                            "description": {
+                                "type": "string",
+                                "default": "",
+                                "description": "Description"
+                            },
+                            "url": {
+                                "type": "string",
+                                "default": "",
+                                "description": "WHEP URL of your WebRTC server"
+                            },
+                            "countryCode": {
+                                "type": "string",
+                                "default": "gb",
+                                "description": "2-letter country code (flag)"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "statusSections": [
+            {
+                "id": "service",
+                "label": "WebRTC Client Config",
+                "fields": [
+                    { "key": "endpoint", "label": "Endpoint" },
+                    { "key": "streamCount", "label": "Streams" },
+                    { "key": "status", "label": "Status" }
+                ]
+            }
+        ],
+        "engine": "./engine/WebRtcClientModule.ts"
+    },
+    "dependencies": {
+        "@media-router/engine": "workspace:*"
+    },
+    "scripts": {
+        "build": "tsc",
+        "typecheck": "tsc --noEmit"
+    }
+}

--- a/plugins/webrtc-client/tsconfig.json
+++ b/plugins/webrtc-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfig.plugin.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./engine"
+    },
+    "include": ["engine"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/engine
 
+  plugins/webrtc-client:
+    dependencies:
+      '@media-router/engine':
+        specifier: workspace:*
+        version: link:../../packages/engine
+
 packages:
 
   '@ampproject/remapping@2.3.0':


### PR DESCRIPTION
- New pure-service engine plugin (no GStreamer pipeline; buildPipeline → null), modelled on n1-mixer. Runs an internal HTTP server bound to 127.0.0.1:2000 serving GET /config.json — not reachable from external devices.
- Publishes the V1.3 WebRTCClient shape consumed by media-router-audio-app: { displayName, webRtcAudioStreams: [{ id, name, url, countryCode, note }] } (description → note, index-based ids).
- Configurable clients array (name / description / url / countryCode) plus a service displayName; both x-live so edits apply without a restart.
- Port conflict (a duplicate instance or a foreign process on the port) sets health=error and stays stopped — no self-disable, no auto-retry.

1865 tests passing across 136 files.