### PR TITLE
fix(ts-splitter): bump PMT version on mid-stream codec change

### DIFF
--- a/packages/engine/src/child-process/ts_psi.py
+++ b/packages/engine/src/child-process/ts_psi.py
@@ -28,6 +28,7 @@ STREAM_TYPE_MPEG2_VIDEO = 0x02
 STREAM_TYPE_PRIVATE_PES = 0x06  # DVB subtitles / teletext ride here
 STREAM_TYPE_AAC = 0x0F
 STREAM_TYPE_AVC = 0x1B
+STREAM_TYPE_HEVC = 0x24
 STREAM_TYPE_KLV = 0x15  # metadata in PES (KLV carousel lives on its own PID)
 
 PCR_HZ = 27_000_000            # PCR is a 27 MHz clock (90 kHz base * 300 + 9-bit ext)

--- a/packages/engine/src/child-process/ts_split.py
+++ b/packages/engine/src/child-process/ts_split.py
@@ -62,6 +62,14 @@ class SplitOutput:
         # for descriptor-identified codecs (Opus = stream_type 0x06 +
         # registration descriptor) dropping it destroys the codec identity.
         self.es_info = b""
+        # PMT version_number, bumped by update() whenever the advertised
+        # stream identity changes. Consumers only re-parse a PSI section when
+        # its version changes (ISO 13818-1; GStreamer's seen_section_before
+        # compares version, never content) — a rewrite at the same version is
+        # invisible to a running demuxer, which then keeps the OLD codec's
+        # parser on the NEW codec's bytes (observed live: transcoder switched
+        # H264→H265 and every downstream re-mux dropped video entirely).
+        self.version = 0
         self.needs_pcr = False       # set on discovery: True when pid != source PCR pid
         self.cc_pat = 0
         self.cc_pmt = 0
@@ -69,12 +77,23 @@ class SplitOutput:
         self.last_pcr = None
         self.since_psi = SPLIT_PSI_INTERVAL_PKTS   # force PSI before the first ES
 
+    def update(self, stream_type: int, es_info: bytes):
+        """Adopt the source-discovered stream identity. A change bumps the
+        PMT version (mod 32) and forces the carousel to re-emit before the
+        next ES packet, so running consumers re-parse immediately."""
+        if stream_type == self.stream_type and es_info == self.es_info:
+            return
+        self.stream_type = stream_type
+        self.es_info = es_info
+        self.version = (self.version + 1) & 0x1F
+        self.since_psi = SPLIT_PSI_INTERVAL_PKTS
+
     def psi(self):
         pat = ts_psi.build_pat(self.ts_id, {1: SPLIT_PMT_PID}, self.cc_pat)
         self.cc_pat = (self.cc_pat + 1) & 0x0F
         pmt = ts_psi.build_pmt(SPLIT_PMT_PID, 1, self.pid,
                                [(self.pid, self.stream_type, self.es_info)],
-                               self.cc_pmt)
+                               self.cc_pmt, self.version)
         self.cc_pmt = (self.cc_pmt + 1) & 0x0F
         return [pat, pmt]
 
@@ -143,8 +162,7 @@ class SplitterCore:
         known = dict(streams)
         for pid, o in self.outputs.items():
             if pid in known:
-                o.stream_type = known[pid]
-                o.es_info = es_info.get(pid, b"")
+                o.update(known[pid], es_info.get(pid, b""))
             o.needs_pcr = pid != self.pcr_pid
         if self.on_discovered is not None:
             self.on_discovered(streams, self.pcr_pid, es_info)

--- a/packages/engine/src/child-process/ts_split_test.py
+++ b/packages/engine/src/child-process/ts_split_test.py
@@ -252,6 +252,75 @@ core_g.set_enabled([])
 out_3 = core_g.feed(source[:188 * 40])
 check("all-disabled feed returns empty dict", out_3 == {})
 
+# --- mid-stream codec change bumps the PMT version -----------------------------------
+# A consumer only re-parses a PSI section when version_number changes (ISO
+# 13818-1; GStreamer's seen_section_before compares version, never content),
+# so a stream_type rewrite at the same version leaves a running tsdemux on the
+# old codec's parser forever (live failure: gate01 H264→H265, downstream
+# re-mux dropped video entirely).
+
+
+def pmt_version(ts: bytes):
+    sec = ts_psi.first_section(
+        [p for p in ts_psi.iter_packets(ts) if ts_psi.ts_pid(p) == ts_split.SPLIT_PMT_PID],
+        ts_split.SPLIT_PMT_PID)
+    return (sec[5] >> 1) & 0x1F if sec else None
+
+
+def build_video_source(stream_type, n_video=400, psi_every=2):
+    out = []
+    cc_pat = cc_pmt = cc_v = 0
+    for i in range(n_video):
+        if i % psi_every == 0:
+            out.append(ts_psi.build_pat(7, {1: PMT_PID}, cc_pat)); cc_pat = (cc_pat + 1) & 0xF
+            out.append(ts_psi.build_pmt(PMT_PID, 1, VIDEO_PID,
+                                        [(VIDEO_PID, stream_type)], cc_pmt))
+            cc_pmt = (cc_pmt + 1) & 0xF
+        out.append(es_packet(VIDEO_PID, cc_v, pusi=(i % 10 == 0))); cc_v = (cc_v + 1) & 0xF
+    return b"".join(out)
+
+
+events_c = []
+core_c = ts_split.SplitterCore(1, [(VIDEO_PID, None)],
+                               on_discovered=lambda s, p, e: events_c.append(tuple(s)))
+before = b"".join(core_c.feed(build_video_source(ts_psi.STREAM_TYPE_AVC)).values())
+check("pre-switch PMT advertises AVC at version 0",
+      ts_psi.parse_pmt([p for p in ts_psi.iter_packets(before)
+                        if ts_psi.ts_pid(p) == ts_split.SPLIT_PMT_PID],
+                       ts_split.SPLIT_PMT_PID)["streams"] == [(VIDEO_PID, ts_psi.STREAM_TYPE_AVC)]
+      and pmt_version(before) == 0)
+
+# Switch codec. Discovery latches the OLDEST retained PSI section and only
+# re-parses every 500 feeds, so push >128 new PMT packets (evicts the AVC
+# ones), then idle-feed across a 500-boundary.
+hevc_src = build_video_source(ts_psi.STREAM_TYPE_HEVC)
+after_parts = [b"".join(core_c.feed(hevc_src[off:off + 2 * PKT]).values())
+               for off in range(0, len(hevc_src), 2 * PKT)]
+for _ in range(500):
+    core_c.feed(b"")
+tail = b"".join(core_c.feed(hevc_src[:40 * PKT]).values())
+check("codec change re-discovered", events_c[-1] == ((VIDEO_PID, ts_psi.STREAM_TYPE_HEVC),))
+tail_pmt = ts_psi.parse_pmt([p for p in ts_psi.iter_packets(tail)
+                             if ts_psi.ts_pid(p) == ts_split.SPLIT_PMT_PID],
+                            ts_split.SPLIT_PMT_PID)
+check("post-switch PMT advertises HEVC", tail_pmt is not None
+      and tail_pmt["streams"] == [(VIDEO_PID, ts_psi.STREAM_TYPE_HEVC)])
+check("post-switch PMT version bumped", pmt_version(tail) == 1)
+tail_pkts = list(ts_psi.iter_packets(tail))
+check("codec change forces PSI before next ES",
+      tail_pkts and ts_psi.ts_pid(tail_pkts[0]) == 0x0000
+      and ts_psi.ts_pid(tail_pkts[1]) == ts_split.SPLIT_PMT_PID)
+
+# update() unit behaviour: no-op on same identity, bump on change, wraps mod 32.
+o = ts_split.SplitOutput(VIDEO_PID, 1, ts_psi.STREAM_TYPE_AVC)
+o.update(ts_psi.STREAM_TYPE_AVC, b"")
+check("update: same identity keeps version", o.version == 0)
+o.update(ts_psi.STREAM_TYPE_AVC, OPUS_DESC)
+check("update: es_info change bumps version", o.version == 1)
+o.version = 31
+o.update(ts_psi.STREAM_TYPE_HEVC, OPUS_DESC)
+check("update: version wraps mod 32", o.version == 0)
+
 print()
 if _failures:
     print("FAILURES:", ", ".join(_failures))


### PR DESCRIPTION
## Problem

Switching the gate01 transcoder to H265 made the re-muxed SRT outputs on ZA-SCC-TECH01 lose video entirely (VLC/OBS/vMix could not play). Root cause traced live on 2026-07-23:

- The ts-splitter's packet-level core rebuilds a single-ES PMT per PID output, but `build_pmt` was always called with the default `version_number = 0`.
- Per ISO 13818-1, a demuxer only re-parses a PSI section when its version changes. GStreamer's `seen_section_before` (mpegtspacketizer.c) compares version only — never content/CRC.
- So when the source codec changed mid-stream (H264 → H265), the splitter corrected `stream_type` 0x1b → 0x24 in its carousel, but every already-running downstream `tsdemux` ignored the same-version rewrite and kept `h264parse` on HEVC bytes. Video silently vanished; no error, no watchdog (TS bytes keep flowing), stable broken state until a manual muxer restart.

## Fix

- `SplitOutput.update()`: adopt discovered stream identity; on change, bump PMT version (mod 32) and force the PSI carousel to re-emit before the next ES packet.
- `SplitterCore._apply_discovery` routes stream identity through `update()` instead of assigning fields directly.
- `psi()` passes the version into `build_pmt` (the parameter existed but was unused).
- `ts_psi`: add `STREAM_TYPE_HEVC` (0x24) constant.

## Testing

- 8 new checks in `ts_split_test.py`: codec-change re-discovery, PMT version bump, forced PSI re-emit before next ES, `update()` unit behaviour (no-op on same identity, bump on es_info change, mod-32 wrap).
- `python3 ts_split_test.py` / `ts_psi_test.py`: all pass.
- Full suite: 1899 of 1901 passing across 142 files (2 pre-existing `unixfdFanout` environment failures on macOS, unrelated).
- Hot-deployed to gate01 + ZA-SCC-TECH01 (2026-07-23): full-chain engine restart now recovers video on the SRT egress with no manual muxer restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)