### PR TITLE
feat(engine): live input swap for single-input bus sinks — non-destructive head-end switch

### DIFF
--- a/packages/engine/src/child-process/GstChildProcess.ts
+++ b/packages/engine/src/child-process/GstChildProcess.ts
@@ -170,24 +170,34 @@ export class GstChildProcess extends EventEmitter {
 
         // Send the pipeline to the child
         try {
-            await this.ipc.sendRequest('startPipeline', {
-                pipeline: this.pipelineDesc.pipeline,
-                useStdioForData: this.pipelineDesc.useStdioForData ?? false,
-                restartOnError: this.pipelineDesc.restartOnError ?? false,
-                restartBackoffMs: this.pipelineDesc.restartBackoffMs,
-                linkOnPadAdded: this.pipelineDesc.linkOnPadAdded ?? [],
-                readKlvNames: this.pipelineDesc.readKlvNames ?? false,
-                env: this.pipelineDesc.env ?? {},
-                clock: this.pipelineDesc.clock,
-                decoderThreadType: this.pipelineDesc.decoderThreadType ?? 'auto',
-                busReports: this.pipelineDesc.busReports ?? [],
-                rist: this.pipelineDesc.rist,
-                tsSplit: this.pipelineDesc.tsSplit,
-                preserveSourceTimeline: this.pipelineDesc.preserveSourceTimeline,
-            });
+            await this.ipc.sendRequest('startPipeline', this.startPayload(this.pipelineDesc));
         } catch (err) {
             this.emit('error', { message: `Failed to start pipeline: ${err}` });
         }
+    }
+
+    /**
+     * The runner-relevant subset of the description, enumerated EXPLICITLY
+     * (a field missing here is silently lost — the decoderThreadType trap).
+     * Shared by `startPipeline` and `updatePipelineDesc` so the replay copy
+     * can never drift from the start copy.
+     */
+    private startPayload(desc: PipelineDescription): Record<string, unknown> {
+        return {
+            pipeline: desc.pipeline,
+            useStdioForData: desc.useStdioForData ?? false,
+            restartOnError: desc.restartOnError ?? false,
+            restartBackoffMs: desc.restartBackoffMs,
+            linkOnPadAdded: desc.linkOnPadAdded ?? [],
+            readKlvNames: desc.readKlvNames ?? false,
+            env: desc.env ?? {},
+            clock: desc.clock,
+            decoderThreadType: desc.decoderThreadType ?? 'auto',
+            busReports: desc.busReports ?? [],
+            rist: desc.rist,
+            tsSplit: desc.tsSplit,
+            preserveSourceTimeline: desc.preserveSourceTimeline,
+        };
     }
 
     /** Stop the pipeline and child process. */
@@ -302,6 +312,32 @@ export class GstChildProcess extends EventEmitter {
     sendBusDetach(socket: string): void {
         if (!this.ipc) return;
         this.ipc.sendEvent('busDetach', { socket });
+    }
+
+    /**
+     * Live input re-point (single-input bus sinks): re-target the named
+     * `unixfdsrc` at a new edge socket without rebuilding the pipeline — the
+     * make-before-break half of a source swap. Tracked RPC (NOT fire-and-
+     * forget): it resolves only once the Python side has the new source
+     * linked and playing, so the caller may then safely detach the OLD edge.
+     */
+    async busReinput(element: string, socket: string): Promise<void> {
+        if (!this.ipc || !this.running) throw new Error('busReinput: pipeline not running');
+        const result = await this.ipc.sendRequest('busReinput', { element, socket }, 5000);
+        throwIfRpcError(result, `busReinput(${element})`);
+    }
+
+    /**
+     * Replace the stored pipeline description after a live mutation (input
+     * swap): the fork-layer restart path rebuilds from `pipelineDesc`, and
+     * the runner-layer respawn replays its own copy — without this update a
+     * later crash-restart replays the ORIGINAL description and gates forever
+     * on an edge socket that no longer exists.
+     */
+    async updatePipelineDesc(desc: PipelineDescription): Promise<void> {
+        this.pipelineDesc = desc;
+        if (!this.ipc || !this.running) return;
+        await this.ipc.sendRequest('updatePipeline', this.startPayload(desc), 2000);
     }
 
     /** Set a property on a named GStreamer element (live, no restart). */

--- a/packages/engine/src/child-process/GstRunner.test.ts
+++ b/packages/engine/src/child-process/GstRunner.test.ts
@@ -189,6 +189,57 @@ describe('GstRunner — Python event routing', () => {
         expect((response?.data as { event: string }).event).toBe('property_set');
     });
 
+    it('resolves busReinput via the runner bus_reinput_done event (tracked RPC)', () => {
+        runner.handleControlMessage({
+            id: 'rpc-ri',
+            type: 'request',
+            action: 'busReinput',
+            data: { element: 'netin', socket: '/tmp/mr-bus-40000-new.sock' },
+        });
+        const pending = (runner as unknown as {
+            ipc: { pending: Map<string, unknown> };
+        }).ipc.pending;
+        expect(pending.size).toBe(1);
+        const [reqId] = [...pending.keys()];
+
+        emit({ event: 'bus_reinput_done', id: reqId });
+
+        const response = lastByType('response');
+        expect(response?.id).toBe('rpc-ri');
+    });
+
+    it('busReinput failure surfaces as command_error (executor falls back to restart)', () => {
+        runner.handleControlMessage({
+            id: 'rpc-ri2',
+            type: 'request',
+            action: 'busReinput',
+            data: { element: 'netin', socket: '/tmp/x.sock' },
+        });
+        const pending = (runner as unknown as {
+            ipc: { pending: Map<string, unknown> };
+        }).ipc.pending;
+        const [reqId] = [...pending.keys()];
+
+        emit({ event: 'command_error', id: reqId, message: "element 'netin' not found" });
+
+        const response = lastByType('response');
+        expect(response?.id).toBe('rpc-ri2');
+        expect(response?.data).toEqual({ error: "element 'netin' not found" });
+    });
+
+    it('updatePipeline replaces the replay description (post-swap crash-restarts use it)', () => {
+        runner.handleControlMessage({
+            id: 'rpc-up',
+            type: 'request',
+            action: 'updatePipeline',
+            data: { pipeline: 'fakesrc ! fakesink', restartOnError: false },
+        });
+        expect(lastByType('response')?.id).toBe('rpc-up');
+        expect(
+            (runner as unknown as { lastStart: { pipeline: string } }).lastStart.pipeline,
+        ).toBe('fakesrc ! fakesink');
+    });
+
     it('forwards the error source `element` on pipeline error events', () => {
         // Attribution from the gst bus message source — diagnostics and
         // per-element policies (e.g. a udpsrc timeout names its udpsrc).

--- a/packages/engine/src/child-process/GstRunner.ts
+++ b/packages/engine/src/child-process/GstRunner.ts
@@ -174,6 +174,31 @@ export class GstRunner {
                 break;
             }
 
+            case 'busReinput': {
+                // Live input re-point: swap the named unixfdsrc onto a new edge
+                // socket without a pipeline rebuild. Tracked — the executor must
+                // know the swap landed before it detaches the old edge.
+                const d = msg.data as { element: string; socket: string };
+                const reqId = this.makeRequestId('reinput');
+                this.ipc.trackPending(reqId, msg.id, 'bus_reinput');
+                this.python?.sendCommand({
+                    cmd: 'bus_reinput',
+                    element: d.element,
+                    socket: d.socket,
+                    id: reqId,
+                });
+                break;
+            }
+
+            case 'updatePipeline': {
+                // Replace the replay description after a live mutation so a
+                // runner-layer respawn rebuilds with the CURRENT sockets, not
+                // the ones from the original start.
+                this.lastStart = msg.data as RunnerStartOptions;
+                this.ipc.sendResponse(msg.id, { ok: true });
+                break;
+            }
+
             default:
                 console.warn(`[gst-runner] Unknown action: ${msg.action}`);
                 this.ipc.sendResponse(msg.id, { error: `Unknown action: ${msg.action}` });
@@ -317,6 +342,7 @@ export class GstRunner {
             case 'throughput':
             case 'property_set':
             case 'tracking':
+            case 'bus_reinput_done':
                 // Round-trip response from a tracked Python request. The
                 // confirmation-only emissions (property_set, tracking) also
                 // carry an id now so the parent's setProperty/trackThroughput

--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -1990,6 +1990,60 @@ def handle_bus_detach(data):
     _teardown_bus_branch(data.get("socket", ""))
 
 
+def handle_bus_reinput(data):
+    """Re-point a named `unixfdsrc` at a new edge socket WITHOUT rebuilding
+    the pipeline — the make-before-break half of a live input swap on a
+    single-input bus sink (ts-splitter head-end). `socket-path` is construct-
+    time-only on unixfdsrc, so the element is replaced: stop → unlink →
+    remove → fresh unixfdsrc (same name, new socket) → add → link → sync.
+    Responds `bus_reinput_done` (tracked RPC) only after the new element is
+    linked and state-synced, so the parent may then detach the OLD edge.
+    On any failure it responds `command_error` and the executor falls back to
+    the classic stop/start restart.
+    """
+    req_id = data.get("id")
+    name = data.get("element", "")
+    socket = data.get("socket", "")
+    if not pipeline:
+        emit_command_error(req_id, "bus_reinput: no pipeline")
+        return
+    if not name or not socket:
+        emit_command_error(req_id, "bus_reinput: element and socket required")
+        return
+    old = pipeline.get_by_name(name)
+    if old is None:
+        emit_command_error(req_id, f"bus_reinput: element '{name}' not found")
+        return
+    src_pad = old.get_static_pad("src")
+    peer = src_pad.get_peer() if src_pad else None
+    if peer is None:
+        emit_command_error(req_id, f"bus_reinput: '{name}' has no linked src pad")
+        return
+    try:
+        # Stopping the source stops dataflow on this branch — no pad blocking
+        # needed (the ingress queue downstream simply runs dry for the gap).
+        old.set_state(Gst.State.NULL)
+        src_pad.unlink(peer)
+        pipeline.remove(old)
+
+        new = Gst.ElementFactory.make("unixfdsrc", name)
+        if new is None:
+            emit_command_error(req_id, "bus_reinput: unixfdsrc factory unavailable")
+            return
+        new.set_property("socket-path", socket)
+        pipeline.add(new)
+        link = new.get_static_pad("src").link(peer)
+        if link != Gst.PadLinkReturn.OK:
+            emit_command_error(req_id, f"bus_reinput: relink failed ({link})")
+            return
+        new.sync_state_with_parent()
+    except GLib.Error as e:
+        emit_command_error(req_id, f"bus_reinput: {e.message}")
+        return
+    sys.stderr.write(f"[gst-runner.py] bus_reinput: {name} -> {socket}\n")
+    emit_event({"event": "bus_reinput_done", "id": req_id})
+
+
 # ---------------------------------------------------------------------------
 # librist integration (rist-input / rist-output as native gst modules)
 #
@@ -2321,6 +2375,7 @@ CMD_HANDLERS = {
     "set_klv_payload": handle_set_klv_payload,
     "bus_attach": handle_bus_attach,
     "bus_detach": handle_bus_detach,
+    "bus_reinput": handle_bus_reinput,
 }
 
 def dispatch_command(line):

--- a/packages/engine/src/modules/ModuleInstance.ts
+++ b/packages/engine/src/modules/ModuleInstance.ts
@@ -300,6 +300,21 @@ export class ModuleInstance extends EventEmitter {
         return this.plugin.getProcessCount?.() ?? 0;
     }
 
+    /** Live-input-swap capability for a sink port (see PluginModule). */
+    getLiveInputSwap(sinkPortId: string): { element: string } | null {
+        return this.plugin.getLiveInputSwap?.(sinkPortId) ?? null;
+    }
+
+    /** Refresh the stored pipeline description after a live input swap. */
+    async refreshPipelineDescription(): Promise<boolean> {
+        return (await this.plugin.refreshPipelineDescription?.()) ?? false;
+    }
+
+    /** Set module health (routing-layer conditions, e.g. pending input swap). */
+    setHealth(health: 'ok' | 'warning' | 'error' | 'stopped', error?: string): void {
+        this.plugin.setHealth?.(health, error);
+    }
+
     /** Get the underlying plugin. */
     getPlugin(): PluginModule {
         return this.plugin;

--- a/packages/engine/src/plugins/GstPluginBase.ts
+++ b/packages/engine/src/plugins/GstPluginBase.ts
@@ -63,6 +63,28 @@ export abstract class GstPluginBase extends EventEmitter implements PluginModule
         return (this.childProcess?.isRunning ? 1 : 0) + (this.vuProcess?.isRunning ? 1 : 0);
     }
 
+    /**
+     * Re-derive the pipeline description from current config/connections and
+     * store it as the restart-replay copy — WITHOUT touching the live
+     * pipeline. Called after a live mutation the pipeline already absorbed
+     * (`bus_reinput` input swap): the swap changed which edge socket the
+     * running `unixfdsrc` reads, so a later crash-restart must rebuild/gate on
+     * the NEW socket, not replay the original description forever against a
+     * socket that no longer exists. Returns false when there is nothing to
+     * refresh (no child, or buildPipeline now returns null).
+     */
+    async refreshPipelineDescription(): Promise<boolean> {
+        if (!this.childProcess) return false;
+        const desc = this.buildPipeline(this.config);
+        if (!desc) return false;
+        if (desc.clockSync && this.services?.clockAuthority) {
+            const clock = await this.services.clockAuthority.getClockConfig();
+            if (clock) desc.clock = clock;
+        }
+        await this.childProcess.updatePipelineDesc(desc);
+        return true;
+    }
+
     /** PipeWire node name for this module instance. */
     protected get pwNodeName(): string {
         if (!this.services?.instanceId) {
@@ -533,8 +555,10 @@ export abstract class GstPluginBase extends EventEmitter implements PluginModule
         this.emit('vuData', data);
     }
 
-    /** Set health status with optional error message. */
-    protected setHealth(health: ModuleHealth, error?: string): void {
+    /** Set health status with optional error message. Public: the routing
+     *  layer also surfaces module-scoped conditions here (e.g. the live
+     *  input-swap pending window — MpegTsBusExecutor). */
+    setHealth(health: ModuleHealth, error?: string): void {
         this.health = health;
         this.error = error;
         this.emit('stateChange', this.getState());

--- a/packages/engine/src/plugins/PluginModule.ts
+++ b/packages/engine/src/plugins/PluginModule.ts
@@ -130,6 +130,26 @@ export interface PluginModule {
     getBusAttachTarget?(): BusAttachTarget | null;
     /** Count of running child processes owned by this module. */
     getProcessCount?(): number;
+    /**
+     * Opt a SINGLE-INPUT bus sink into live input swapping: when the operator
+     * re-wires the given input port's source, `MpegTsBusExecutor` re-points
+     * the named `unixfdsrc` at the new edge socket (make-before-break) instead
+     * of stop/starting the module — so the module's own producer sockets stay
+     * up and the downstream graph never notices (the 2026-07-23 head-end
+     * switch cascade). Return null (or omit) for ports whose pipeline SHAPE
+     * depends on the source — those keep the classic restart.
+     */
+    getLiveInputSwap?(sinkPortId: string): { element: string } | null;
+    /**
+     * Re-derive and store the pipeline description after a live mutation the
+     * running pipeline already absorbed (bus_reinput input swap), so
+     * crash-restarts replay the CURRENT graph. Implemented by GstPluginBase;
+     * returns false when there is nothing to refresh.
+     */
+    refreshPipelineDescription?(): Promise<boolean>;
+    /** Set module health (implemented by the plugin bases; used by the
+     *  routing layer for module-scoped conditions like a pending input swap). */
+    setHealth?(health: 'ok' | 'warning' | 'error' | 'stopped', error?: string): void;
 }
 
 /**

--- a/packages/engine/src/plugins/busRunnerContract.test.ts
+++ b/packages/engine/src/plugins/busRunnerContract.test.ts
@@ -45,6 +45,13 @@ describe('bus helpers ↔ gst-pipeline-runner contracts', () => {
         expect(runnerSource).toContain('"bus_detach"');
     });
 
+    it('the gst runner handles the bus_reinput wire command (live input swap)', () => {
+        expect(runnerSource).toContain('"bus_reinput"');
+        expect(runnerSource).toContain('def handle_bus_reinput');
+        // The tracked-RPC response event GstRunner resolves on.
+        expect(runnerSource).toContain('"event": "bus_reinput_done"');
+    });
+
     it('the runner implements the preserveSourceTimeline start option', () => {
         // GstChildProcess sends `preserveSourceTimeline: { demux }` in the
         // start payload (PipelineDescription contract); the runner must read

--- a/packages/engine/src/routing/LiveInputSwap.test.ts
+++ b/packages/engine/src/routing/LiveInputSwap.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PendingInputSwaps, SWAP_WINDOW_MS, performLiveSwap } from './LiveInputSwap.js';
+import type { Connection } from './MediaRouter.js';
+import type { ModuleInstance } from '../modules/ModuleInstance.js';
+
+function conn(id: string, sink = 'splitter-1', port = 'mpegts-in'): Connection {
+    return {
+        id,
+        sourceModuleId: `src-${id}`,
+        sourcePortId: 'mpegts-out',
+        sinkModuleId: sink,
+        sinkPortId: port,
+        streamType: 'muxed/mpegts',
+    } as Connection;
+}
+
+describe('PendingInputSwaps', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('claim within the window cancels finalize and returns the entry', async () => {
+        const swaps = new PendingInputSwaps();
+        const finalize = vi.fn(async () => {});
+        swaps.defer({ conn: conn('a') }, finalize);
+
+        const claimed = swaps.claim(conn('b'));
+        expect(claimed?.conn.id).toBe('a');
+        expect(swaps.size).toBe(0);
+
+        await vi.advanceTimersByTimeAsync(SWAP_WINDOW_MS + 1000);
+        expect(finalize).not.toHaveBeenCalled();
+    });
+
+    it('expiry runs finalize exactly once and later claims miss', async () => {
+        const swaps = new PendingInputSwaps();
+        const finalize = vi.fn(async () => {});
+        swaps.defer({ conn: conn('a') }, finalize);
+
+        await vi.advanceTimersByTimeAsync(SWAP_WINDOW_MS + 1);
+        expect(finalize).toHaveBeenCalledTimes(1);
+        expect(swaps.claim(conn('b'))).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(SWAP_WINDOW_MS);
+        expect(finalize).toHaveBeenCalledTimes(1);
+    });
+
+    it('a second defer on the same sink:port finalizes the first immediately', async () => {
+        const swaps = new PendingInputSwaps();
+        const f1 = vi.fn(async () => {});
+        const f2 = vi.fn(async () => {});
+        swaps.defer({ conn: conn('a') }, f1);
+        swaps.defer({ conn: conn('b') }, f2);
+
+        expect(f1).toHaveBeenCalledTimes(1);
+        expect(f2).not.toHaveBeenCalled();
+        expect(swaps.claim(conn('c'))?.conn.id).toBe('b');
+    });
+
+    it('windows on different sink ports are independent', () => {
+        const swaps = new PendingInputSwaps();
+        swaps.defer({ conn: conn('a', 'splitter-1') }, async () => {});
+        swaps.defer({ conn: conn('b', 'splitter-2') }, async () => {});
+        expect(swaps.size).toBe(2);
+        expect(swaps.claim(conn('x', 'splitter-2'))?.conn.id).toBe('b');
+        expect(swaps.claim(conn('y', 'splitter-1'))?.conn.id).toBe('a');
+    });
+});
+
+describe('performLiveSwap', () => {
+    function sinkStub(overrides: Partial<Record<string, unknown>> = {}) {
+        const busReinput = vi.fn(async () => {});
+        const sink = {
+            running: true,
+            getLiveInputSwap: vi.fn(() => ({ element: 'netin' })),
+            getChildProcess: vi.fn(() => ({ busReinput })),
+            refreshPipelineDescription: vi.fn(async () => true),
+            setHealth: vi.fn(),
+            ...overrides,
+        } as unknown as ModuleInstance;
+        return { sink, busReinput };
+    }
+
+    it('detaches the old edge and returns false when the sink lost the capability', async () => {
+        const { sink } = sinkStub({ getLiveInputSwap: vi.fn(() => null) });
+        const detach = vi.fn();
+        const ok = await performLiveSwap({
+            sink,
+            conn: conn('new'),
+            oldConn: conn('old'),
+            udpPort: 40001,
+            busFanout: { detach } as never,
+        });
+        expect(ok).toBe(false);
+        expect(detach).toHaveBeenCalledWith(expect.objectContaining({ id: 'old' }));
+    });
+
+    it('falls back (false + old-edge detach) when the edge socket never appears', async () => {
+        // No socket exists at the edge path in this test env, so the probe
+        // loop times out — the failure path must detach the old edge.
+        const { sink, busReinput } = sinkStub();
+        const detach = vi.fn();
+        const ok = await performLiveSwap({
+            sink,
+            conn: conn('new'),
+            oldConn: conn('old'),
+            udpPort: 40001,
+            busFanout: { detach } as never,
+            edgeWaitMs: 350,
+        });
+        expect(ok).toBe(false);
+        expect(busReinput).not.toHaveBeenCalled();
+        expect(detach).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/engine/src/routing/LiveInputSwap.ts
+++ b/packages/engine/src/routing/LiveInputSwap.ts
@@ -1,0 +1,151 @@
+import { createLogger } from '@media-router/shared-types';
+import { busEdgeSocketPath } from '../plugins/busHelpers.js';
+import { probeUnixSocket } from '../child-process/busSocketGate.js';
+import type { Connection } from './MediaRouter.js';
+import type { ModuleInstance } from '../modules/ModuleInstance.js';
+import type { BusFanoutCoordinator } from './BusFanoutCoordinator.js';
+
+const log = createLogger('LiveInputSwap');
+
+/**
+ * How long a removed single-input edge waits for its replacement before the
+ * classic teardown (fanout detach + sink stop/start) runs. 15 s covers a
+ * leisurely manual re-wire in the UI (user decision 2026-07-23); the accepted
+ * cost is that a module whose input was genuinely disconnected keeps
+ * streaming the OLD source for up to this long before idling — surfaced as a
+ * health warning by the executor while the window is open.
+ */
+export const SWAP_WINDOW_MS = 15_000;
+
+/** How long the swap path waits for the NEW producer edge socket. */
+const EDGE_SOCKET_WAIT_MS = 5_000;
+
+export interface PendingSwap {
+    conn: Connection;
+}
+
+interface PendingRecord {
+    entry: PendingSwap;
+    timer: ReturnType<typeof setTimeout>;
+    consumed: boolean;
+    finalize: (entry: PendingSwap) => Promise<void>;
+}
+
+/**
+ * Deferred-teardown window for live input swaps (make-before-break): a
+ * removed edge on a swap-capable single-input sink is NOT torn down
+ * immediately — the old producer edge stays attached so the sink never sees
+ * a dead socket. A matching add on the same sink:port within the window
+ * `claim()`s the entry and re-points the input live; expiry runs the classic
+ * teardown via `finalize`.
+ */
+export class PendingInputSwaps {
+    private pending = new Map<string, PendingRecord>();
+
+    static key(conn: Connection): string {
+        return `${conn.sinkModuleId}:${conn.sinkPortId}`;
+    }
+
+    /** Number of open windows (for tests / diagnostics). */
+    get size(): number {
+        return this.pending.size;
+    }
+
+    defer(
+        entry: PendingSwap,
+        finalize: (entry: PendingSwap) => Promise<void>,
+        windowMs = SWAP_WINDOW_MS,
+    ): void {
+        const key = PendingInputSwaps.key(entry.conn);
+        // A second remove on the same sink:port while one is pending — the
+        // sink can only hold one old edge, so finalize the first immediately.
+        const existing = this.pending.get(key);
+        if (existing && !existing.consumed) {
+            existing.consumed = true;
+            clearTimeout(existing.timer);
+            void existing.finalize(existing.entry).catch((err) =>
+                log.warn({ err, key }, 'Superseded pending-swap finalize failed'),
+            );
+        }
+        const rec: PendingRecord = {
+            entry,
+            consumed: false,
+            finalize,
+            timer: setTimeout(() => {
+                if (rec.consumed) return;
+                rec.consumed = true;
+                this.pending.delete(key);
+                log.info({ key }, 'Input-swap window expired — running classic teardown');
+                void finalize(entry).catch((err) =>
+                    log.warn({ err, key }, 'Pending-swap finalize failed'),
+                );
+            }, windowMs),
+        };
+        this.pending.set(key, rec);
+    }
+
+    /** Claim the pending entry for this sink:port (cancels its timer). */
+    claim(conn: Connection): PendingSwap | null {
+        const key = PendingInputSwaps.key(conn);
+        const rec = this.pending.get(key);
+        if (!rec || rec.consumed) return null;
+        rec.consumed = true;
+        clearTimeout(rec.timer);
+        this.pending.delete(key);
+        return rec.entry;
+    }
+}
+
+/**
+ * The live-swap procedure (the ADD half, after `PendingInputSwaps.claim`).
+ * The NEW producer edge must already be attached by the caller. Ordering is
+ * make-before-break: wait for the new edge socket, refresh the sink's stored
+ * pipeline description (crash-replays must gate on the NEW socket), then the
+ * tracked `bus_reinput` RPC — only after it confirms is the OLD edge
+ * detached. Returns true on success; on ANY failure detaches the old edge
+ * and returns false so the caller falls back to the classic restart.
+ */
+export async function performLiveSwap(opts: {
+    sink: ModuleInstance;
+    conn: Connection;
+    oldConn: Connection;
+    udpPort: number;
+    busFanout?: BusFanoutCoordinator;
+    /** Override for tests — how long to wait for the new edge socket. */
+    edgeWaitMs?: number;
+}): Promise<boolean> {
+    const { sink, conn, oldConn, udpPort, busFanout } = opts;
+    const swap = sink.getLiveInputSwap?.(conn.sinkPortId);
+    const child = sink.getChildProcess?.();
+    if (!swap || !child || !sink.running) {
+        busFanout?.detach(oldConn);
+        return false;
+    }
+    try {
+        const edge = busEdgeSocketPath(udpPort, conn.id);
+        const deadline = Date.now() + (opts.edgeWaitMs ?? EDGE_SOCKET_WAIT_MS);
+        while (!(await probeUnixSocket(edge))) {
+            if (Date.now() > deadline) {
+                throw new Error(`new edge socket never appeared: ${edge}`);
+            }
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        await sink.refreshPipelineDescription?.();
+        await child.busReinput(swap.element, edge);
+        busFanout?.detach(oldConn);
+        // Clear the pending-window warning set at teardown-defer time.
+        sink.setHealth?.('ok');
+        log.info(
+            { sink: conn.sinkModuleId, port: conn.sinkPortId, edge },
+            'Live input swap complete — downstream untouched',
+        );
+        return true;
+    } catch (err) {
+        log.warn(
+            { err, sink: conn.sinkModuleId, port: conn.sinkPortId },
+            'Live input swap failed — falling back to module restart',
+        );
+        busFanout?.detach(oldConn);
+        return false;
+    }
+}

--- a/packages/engine/src/routing/MpegTsBusExecutor.test.ts
+++ b/packages/engine/src/routing/MpegTsBusExecutor.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:net';
+import { MpegTsBusExecutor } from './MpegTsBusExecutor.js';
+import { busEdgeSocketPath } from '../plugins/busHelpers.js';
+import type { Connection } from './MediaRouter.js';
+import type { ModuleInstance } from '../modules/ModuleInstance.js';
+
+const PORT = 40001;
+
+function conn(id: string, source = 'input-A'): Connection {
+    return {
+        id,
+        sourceModuleId: source,
+        sourcePortId: 'mpegts-out',
+        sinkModuleId: 'splitter-1',
+        sinkPortId: 'mpegts-in',
+        streamType: 'muxed/mpegts',
+    } as Connection;
+}
+
+function sinkStub(opts: { swapCapable?: boolean } = {}) {
+    const busReinput = vi.fn(async () => {});
+    const sink = {
+        running: true,
+        stop: vi.fn(async () => {}),
+        start: vi.fn(async () => {}),
+        setHealth: vi.fn(),
+        refreshPipelineDescription: vi.fn(async () => true),
+        getLiveInputSwap: vi.fn(() =>
+            (opts.swapCapable ?? true) ? { element: 'netin' } : null,
+        ),
+        getChildProcess: vi.fn(() => ({ busReinput })),
+        getDynamicPorts: vi.fn(() => []),
+    } as unknown as ModuleInstance;
+    return { sink, busReinput };
+}
+
+function makeExecutor(sink: ModuleInstance) {
+    const fanout = { attach: vi.fn(), detach: vi.fn() };
+    const executor = new MpegTsBusExecutor(
+        () => sink,
+        () => PORT,
+        (c) => c.id,
+        undefined,
+        fanout as never,
+    );
+    return { executor, fanout };
+}
+
+describe('MpegTsBusExecutor live input swap', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('defers teardown for a swap-capable running sink: no detach, no restart, warning set', async () => {
+        const { sink } = sinkStub();
+        const { executor, fanout } = makeExecutor(sink);
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old'),
+            false,
+        );
+
+        expect(fanout.detach).not.toHaveBeenCalled();
+        expect((sink as any).stop).not.toHaveBeenCalled();
+        expect((sink as any).setHealth).toHaveBeenCalledWith(
+            'warning',
+            expect.stringContaining('Input disconnect pending'),
+        );
+    });
+
+    it('window expiry runs the classic teardown (detach + stop/start)', async () => {
+        const { sink } = sinkStub();
+        const { executor, fanout } = makeExecutor(sink);
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old'),
+            false,
+        );
+        await vi.advanceTimersByTimeAsync(16_000);
+
+        expect(fanout.detach).toHaveBeenCalledTimes(1);
+        expect((sink as any).stop).toHaveBeenCalledTimes(1);
+        expect((sink as any).start).toHaveBeenCalledTimes(1);
+    });
+
+    it('non-capable sink keeps today\'s behaviour: immediate detach + restart', async () => {
+        const { sink } = sinkStub({ swapCapable: false });
+        const { executor, fanout } = makeExecutor(sink);
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old'),
+            false,
+        );
+
+        expect(fanout.detach).toHaveBeenCalledTimes(1);
+        expect((sink as any).stop).toHaveBeenCalledTimes(1);
+        expect((sink as any).start).toHaveBeenCalledTimes(1);
+    });
+
+    it('skipModuleRestart still detaches immediately and never defers', async () => {
+        const { sink } = sinkStub();
+        const { executor, fanout } = makeExecutor(sink);
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old'),
+            true,
+        );
+
+        expect(fanout.detach).toHaveBeenCalledTimes(1);
+        expect((sink as any).stop).not.toHaveBeenCalled();
+    });
+});
+
+describe('MpegTsBusExecutor swap execution (real edge socket)', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+        if (server) {
+            await new Promise((r) => server!.close(r));
+            server = null;
+        }
+    });
+
+    it('remove-then-add swaps live: bus_reinput lands, old edge detached, sink never restarted', async () => {
+        const { sink, busReinput } = sinkStub();
+        const { executor, fanout } = makeExecutor(sink);
+        const newConn = conn('input-B:mpegts-out-splitter-1:mpegts-in', 'input-B');
+
+        // The producer edge socket the swap path waits on.
+        const edgePath = busEdgeSocketPath(PORT, newConn.id);
+        server = createServer();
+        await new Promise<void>((res) => server!.listen(edgePath, res));
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old', 'input-A'),
+            false,
+        );
+        const handle = await executor.execute(newConn);
+
+        expect(handle).toMatchObject({ connectionId: newConn.id, busChannel: PORT });
+        expect(busReinput).toHaveBeenCalledWith('netin', edgePath);
+        expect((sink as any).refreshPipelineDescription).toHaveBeenCalled();
+        // Old edge detached exactly once, new edge attached, no sink restart.
+        expect(fanout.detach).toHaveBeenCalledTimes(1);
+        expect(fanout.attach).toHaveBeenCalledWith(newConn);
+        expect((sink as any).stop).not.toHaveBeenCalled();
+        expect((sink as any).start).not.toHaveBeenCalled();
+        // Pending-window warning cleared on success.
+        expect((sink as any).setHealth).toHaveBeenCalledWith('ok');
+    });
+
+    it('falls back to the classic restart when bus_reinput fails', async () => {
+        const { sink } = sinkStub();
+        (sink.getChildProcess as any) = vi.fn(() => ({
+            busReinput: vi.fn(async () => {
+                throw new Error('runner rejected');
+            }),
+        }));
+        const { executor, fanout } = makeExecutor(sink);
+        const newConn = conn('input-B:mpegts-out-splitter-1:mpegts-in', 'input-B');
+
+        const edgePath = busEdgeSocketPath(PORT, newConn.id);
+        server = createServer();
+        await new Promise<void>((res) => server!.listen(edgePath, res));
+
+        await executor.teardown(
+            { connectionId: 'old', type: 'bus', busChannel: PORT },
+            conn('old', 'input-A'),
+            false,
+        );
+        const handle = await executor.execute(newConn);
+
+        // Old edge detached by the failure path, then the classic restart ran.
+        expect(fanout.detach).toHaveBeenCalledTimes(1);
+        expect((sink as any).stop).toHaveBeenCalledTimes(1);
+        expect((sink as any).start).toHaveBeenCalledTimes(1);
+        expect(handle).toMatchObject({ connectionId: newConn.id, busChannel: PORT });
+    });
+});

--- a/packages/engine/src/routing/MpegTsBusExecutor.ts
+++ b/packages/engine/src/routing/MpegTsBusExecutor.ts
@@ -3,6 +3,7 @@ import type { ModuleInstance } from '../modules/ModuleInstance.js';
 import type { Connection, ActiveHandle } from './MediaRouter.js';
 import type { StreamTypeExecutor } from './StreamTypeExecutor.js';
 import type { BusFanoutCoordinator } from './BusFanoutCoordinator.js';
+import { PendingInputSwaps, performLiveSwap } from './LiveInputSwap.js';
 
 const log = createLogger('MpegTsBusExecutor');
 
@@ -75,6 +76,26 @@ export class MpegTsBusExecutor implements StreamTypeExecutor {
         // so its edge socket exists by the time the consumer's `unixfdsrc`
         // connects (the consumer's busSocketGate waits for it). Idempotent.
         this.busFanout?.attach(conn);
+
+        // Live input swap: a remove on this sink:port opened a pending window
+        // (see teardown) — the sink is still running against the OLD edge.
+        // Re-point its input at the new edge instead of restarting it, so its
+        // own producer sockets stay up and the downstream graph never notices.
+        const pending = this.pendingSwaps.claim(conn);
+        if (pending) {
+            const swapped = await performLiveSwap({
+                sink: sinkModule,
+                conn,
+                oldConn: pending.conn,
+                udpPort,
+                busFanout: this.busFanout,
+            });
+            if (swapped) {
+                return { connectionId: conn.id, type: 'bus', busChannel: udpPort };
+            }
+            // Fall through: performLiveSwap already detached the old edge —
+            // the classic restart below rebuilds against the new connection.
+        }
 
         // Start/restart the consumer so it connects to the producer's edge socket
         try {
@@ -169,6 +190,13 @@ export class MpegTsBusExecutor implements StreamTypeExecutor {
         return this.getUdpPort(conn.sourceModuleId, conn.sourcePortId);
     }
 
+    /**
+     * Deferred-teardown windows for swap-capable single-input sinks (see
+     * LiveInputSwap). While a window is open the OLD producer edge stays
+     * attached (make-before-break) and the sink keeps running.
+     */
+    private pendingSwaps = new PendingInputSwaps();
+
     async teardown(
         handle: ActiveHandle,
         conn: Connection | undefined,
@@ -180,25 +208,50 @@ export class MpegTsBusExecutor implements StreamTypeExecutor {
         );
         this.materializeAttempted.delete(handle.connectionId);
 
+        // Live-swap-capable sink: defer the ENTIRE physical teardown (edge
+        // detach + sink restart) — a matching add within the window re-points
+        // the input live; expiry runs the classic path below. The sink keeps
+        // streaming the old source meanwhile, surfaced as a health warning.
+        if (conn && !skipModuleRestart) {
+            const sink = this.moduleGetter(conn.sinkModuleId);
+            if (
+                sink?.running &&
+                sink.getLiveInputSwap?.(conn.sinkPortId) &&
+                sink.getChildProcess?.()
+            ) {
+                sink.setHealth?.(
+                    'warning',
+                    'Input disconnect pending — still streaming previous source',
+                );
+                this.pendingSwaps.defer({ conn }, async (entry) => {
+                    this.busFanout?.detach(entry.conn);
+                    await this.restartSinkIdle(entry.conn);
+                });
+                return;
+            }
+        }
+
         // Tear down the producer's fan-out branch for this edge.
         if (conn) this.busFanout?.detach(conn);
 
         if (skipModuleRestart) return;
 
-        // Stop then restart the sink so its buildPipeline returns null
-        // (connection already deleted) and it sits idle.
-        if (conn) {
-            const sink = this.moduleGetter(conn.sinkModuleId);
-            if (sink?.running) {
-                try {
-                    await sink.stop();
-                    await sink.start();
-                } catch (err) {
-                    log.debug(
-                        { err, moduleId: conn.sinkModuleId },
-                        'Consumer restart after disconnect failed',
-                    );
-                }
+        if (conn) await this.restartSinkIdle(conn);
+    }
+
+    /** Classic disconnect: stop then restart the sink so its buildPipeline
+     *  returns null (connection already deleted) and it sits idle. */
+    private async restartSinkIdle(conn: Connection): Promise<void> {
+        const sink = this.moduleGetter(conn.sinkModuleId);
+        if (sink?.running) {
+            try {
+                await sink.stop();
+                await sink.start();
+            } catch (err) {
+                log.debug(
+                    { err, moduleId: conn.sinkModuleId },
+                    'Consumer restart after disconnect failed',
+                );
             }
         }
     }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -937,6 +937,30 @@ getPipeWireNodeForPort(portId: string): { source?: string; sink?: string } {
 
 Real examples: [`n1-mixer`](n1-mixer/engine/N1MixerModule.ts) (per-port PipeWire nodes), [`ts-splitter`](ts-splitter/engine/TsSplitterModule.ts) and [`mpegts-muxer`](mpegts-muxer/engine/MpegTsMuxerModule.ts) (dynamic outputs/inputs based on stream counts).
 
+### Live Input Swap (`getLiveInputSwap`)
+
+By default, adding or removing a `muxed/mpegts` connection **restarts the sink
+module** (its `buildPipeline` must re-run). For a SINGLE-INPUT module whose
+pipeline shape does not depend on which source feeds it, that restart is pure
+damage: the module's own producer sockets close and every downstream consumer
+restarts too (the head-end switch cascade). Opt out by declaring the input
+`unixfdsrc` swappable:
+
+```typescript
+getLiveInputSwap(sinkPortId: string): { element: string } | null {
+    return sinkPortId === INPUT_PORT_ID ? { element: INPUT_SRC_NAME } : null;
+}
+```
+
+The engine then handles a source re-wire make-before-break: the removed edge
+stays attached for a 15 s window (module health shows a warning); a matching
+add re-points the named `unixfdsrc` at the new edge socket via the runner's
+`bus_reinput` command — outputs and downstream consumers never notice. Window
+expiry (a plain disconnect) runs the classic teardown. Only declare this for
+ports where a source swap changes NOTHING in `buildPipeline` besides the input
+socket; modules whose branch set depends on the source (mpegts-muxer) must
+keep the restart. Real example: [`ts-splitter`](ts-splitter/engine/TsSplitterModule.ts).
+
 ### Device Watchdog (Hardware Hot-Plug)
 
 Plugins bound to a specific hardware device (USB mic, HDMI display, V4L2 camera) can opt into a hot-plug watchdog that polls PipeWire every 2 s and calls subclass hooks on disconnect/reconnect. Override `getWatchedDeviceName()` to enable; the base class handles the polling.

--- a/plugins/ts-splitter/engine/TsSplitterModule.test.ts
+++ b/plugins/ts-splitter/engine/TsSplitterModule.test.ts
@@ -80,6 +80,12 @@ describe('TsSplitterModule.buildPipeline', () => {
         expect(desc!.pipeline).toContain('appsrc name=out_0xc9');
     });
 
+    it('declares live input swap on mpegts-in targeting the input unixfdsrc', () => {
+        const { module } = makeModule();
+        expect(module.getLiveInputSwap('mpegts-in')).toEqual({ element: 'netin' });
+        expect(module.getLiveInputSwap('pid-0x65')).toBeNull();
+    });
+
     it('port pool exhaustion -> error health + null', () => {
         const { module } = makeModule();
         (module as any).services.mediaRouter.assignBusChannel = vi.fn(() => undefined);

--- a/plugins/ts-splitter/engine/TsSplitterModule.ts
+++ b/plugins/ts-splitter/engine/TsSplitterModule.ts
@@ -13,7 +13,7 @@ import {
     type DiscoveredStreamConfig,
     type DynamicPort,
 } from './splitterPorts.js';
-import { buildSplitterPipeline } from './splitterPipeline.js';
+import { buildSplitterPipeline, INPUT_SRC_NAME } from './splitterPipeline.js';
 import { formatPid, languageFromEsInfo, streamLabel, streamTypeInfo } from './streamTypes.js';
 
 /**
@@ -108,6 +108,18 @@ export class TsSplitterModule extends GstPluginBase {
             tsId: (config.tsId as number) ?? 1,
         });
         return { pipeline, restartOnError: true, tsSplit };
+    }
+
+    /**
+     * Live input swap (engine `bus_reinput`): the splitter's pipeline shape
+     * does not depend on WHICH source feeds it — the input `unixfdsrc` can be
+     * re-pointed at a new edge socket while every output appsrc chain (and
+     * all downstream consumers) keeps running. Discovery re-converges from
+     * the new source's PSI on the same channel. This is what makes a
+     * head-end source switch non-destructive (2026-07-23 incident).
+     */
+    getLiveInputSwap(sinkPortId: string): { element: string } | null {
+        return sinkPortId === INPUT_PORT_ID ? { element: INPUT_SRC_NAME } : null;
     }
 
     async onStart(): Promise<void> {

--- a/plugins/ts-splitter/engine/splitterPipeline.ts
+++ b/plugins/ts-splitter/engine/splitterPipeline.ts
@@ -15,6 +15,12 @@ import { buildBusSink, buildBusSrc, type TsSplitRunnerConfig } from '@media-rout
 
 export const INPUT_APPSINK = 'splitin';
 
+/** `name=` of the input `unixfdsrc` — the target of the engine's live
+ *  input-swap (`bus_reinput`): the source edge can be re-pointed without
+ *  restarting this module, so its output appsrc chains (and every
+ *  downstream consumer) stay up across a head-end source switch. */
+export const INPUT_SRC_NAME = 'netin';
+
 export function pidAppsrcName(pid: number): string {
     return `out_0x${pid.toString(16)}`;
 }
@@ -35,7 +41,7 @@ export function buildSplitterPipeline(input: SplitterPipelineInput): {
     const src = buildBusSrc({
         port: input.input.port,
         socketPath: input.input.socketPath,
-        name: 'netin',
+        name: INPUT_SRC_NAME,
     });
     const chains = [`${src} ! appsink name=${INPUT_APPSINK}`];
 


### PR DESCRIPTION
## Summary
Stacked on #700 (retarget to v2.0 after it merges).

- `MpegTsBusExecutor` defers the physical teardown of a removed edge on a swap-capable single-input sink for a 15 s window (`PendingInputSwaps`) — the old producer edge stays attached (make-before-break). A matching add on the same sink:port re-points the input live via the new runner `bus_reinput` RPC instead of stop/starting the sink, so the sink's own producer sockets stay up and the downstream graph never notices. Window expiry runs today's classic teardown; RPC failure falls back to the classic restart.
- `GstChildProcess.updatePipelineDesc` + `GstPluginBase.refreshPipelineDescription` keep crash-replays gating on the post-swap socket.
- ts-splitter opts in (`getLiveInputSwap` → its `netin` unixfdsrc); the pending window surfaces a module health warning.

Context: the 2026-07-23 incident — one UI input switch stop/started the ts-splitter twice, closing all its producer sockets and cascading restarts through the whole downstream graph (472 pipeline restarts, RIST flow resets, vMix drops).

## Validation (live, gate01)
- Two head-end source swaps with **zero** splitter pipeline restarts, downstream untouched ("Live input swap complete — downstream untouched").
- Caveat surfaced during testing: swapping onto a non-producing source still starves downstream ~5 s later (transport-level swap is safe; source liveness is not guaranteed). Hardening candidate for a follow-up: require producer throughput before claiming the swap.

1922 tests passing across 144 files (2 pre-existing env-only failures: unixfdFanout needs python gi, absent on macOS dev boxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)