### PR TITLE
feat: detect Raspberry Pi under-voltage and warn in the manager UI

### DIFF
--- a/packages/engine/src/system/SystemStatsCollector.test.ts
+++ b/packages/engine/src/system/SystemStatsCollector.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { readCpuTemp, readCoretempAverage } from './SystemStatsCollector.js';
+import {
+    readCpuTemp,
+    readCoretempAverage,
+    readUndervoltage,
+    SystemStatsCollector,
+} from './SystemStatsCollector.js';
 
 describe('readCoretempAverage', () => {
     const root = path.join(__dirname, '__test-hwmon__');
@@ -133,5 +138,87 @@ describe('readCpuTemp', () => {
 
     it('returns null when neither coretemp nor thermal zones are available', () => {
         expect(readCpuTemp(path.join(root, 'does-not-exist'), noHwmon)).toBeNull();
+    });
+});
+
+describe('readUndervoltage', () => {
+    const root = path.join(__dirname, '__test-uvhwmon__');
+
+    /** Write a hwmon device with the given name, optionally an in0_lcrit_alarm. */
+    function voltDev(index: number, name: string, alarm?: 0 | 1): void {
+        const dir = path.join(root, `hwmon${index}`);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'name'), `${name}\n`);
+        if (alarm !== undefined) {
+            fs.writeFileSync(path.join(dir, 'in0_lcrit_alarm'), `${alarm}\n`);
+        }
+    }
+
+    beforeEach(() => fs.mkdirSync(root, { recursive: true }));
+    afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    it('returns true when rpi_volt reports the critical alarm (under-voltage)', () => {
+        voltDev(0, 'cpu_thermal'); // unrelated device also present
+        voltDev(1, 'rpi_volt', 1);
+        expect(readUndervoltage(root)).toBe(true);
+    });
+
+    it('returns false when rpi_volt reports the rail is OK', () => {
+        voltDev(1, 'rpi_volt', 0);
+        expect(readUndervoltage(root)).toBe(false);
+    });
+
+    it('returns null when there is no rpi_volt device (non-Pi hardware)', () => {
+        voltDev(0, 'coretemp');
+        voltDev(1, 'acpitz');
+        expect(readUndervoltage(root)).toBeNull();
+    });
+
+    it('returns null when rpi_volt exists but the alarm attribute is missing', () => {
+        voltDev(1, 'rpi_volt'); // no in0_lcrit_alarm file
+        expect(readUndervoltage(root)).toBeNull();
+    });
+
+    it('returns null when the hwmon subsystem is absent', () => {
+        expect(readUndervoltage(path.join(root, 'nope'))).toBeNull();
+    });
+});
+
+describe('SystemStatsCollector under-voltage debounce + latch', () => {
+    // Drive the extracted streak/latch step directly (private, reached via index
+    // access) so the 2-consecutive boundary is tested without the interval.
+    function step(c: SystemStatsCollector, reading: boolean | null): boolean {
+        return (c as unknown as { updateUndervoltage(r: boolean | null): boolean })[
+            'updateUndervoltage'
+        ](reading);
+    }
+    const make = () => new SystemStatsCollector(() => {});
+
+    it('does not arm on a single under-voltage sample (debounce)', () => {
+        const c = make();
+        expect(step(c, true)).toBe(false); // one sample — not yet
+        expect(step(c, false)).toBe(false); // recovered before the 2nd
+    });
+
+    it('arms on 2 consecutive under-voltage samples', () => {
+        const c = make();
+        expect(step(c, true)).toBe(false);
+        expect(step(c, true)).toBe(true); // 2nd consecutive → latched
+    });
+
+    it('stays latched once armed, even after readings recover', () => {
+        const c = make();
+        step(c, true);
+        step(c, true); // armed
+        expect(step(c, false)).toBe(true);
+        expect(step(c, null)).toBe(true);
+        expect(step(c, false)).toBe(true);
+    });
+
+    it('a null reading resets the streak like an OK read (non-Pi never latches)', () => {
+        const c = make();
+        expect(step(c, true)).toBe(false);
+        expect(step(c, null)).toBe(false); // gap breaks the streak
+        expect(step(c, true)).toBe(false); // only 1 consecutive again
     });
 });

--- a/packages/engine/src/system/SystemStatsCollector.ts
+++ b/packages/engine/src/system/SystemStatsCollector.ts
@@ -9,6 +9,12 @@ export interface SystemStats {
     cpu: number;
     mem: number;
     temp: number | null;
+    /**
+     * Raspberry Pi under-voltage warning. Only ever `true` (and only once the
+     * collector has latched — see below); omitted otherwise, so non-Pi hosts and
+     * healthy boxes send nothing.
+     */
+    undervoltage?: boolean;
     processCount?: number;
     ip?: string;
     ips?: string[];
@@ -138,6 +144,51 @@ export function readCpuTemp(
 }
 
 /**
+ * Read the Raspberry Pi under-voltage flag.
+ *
+ * The `raspberrypi_hwmon` firmware driver exposes a hwmon device named
+ * `rpi_volt` with a single attribute `in0_lcrit_alarm`: `1` = the 5 V rail has
+ * sagged below the critical threshold (the firmware is throttling the ARM
+ * clock), `0` = OK. This is the same signal Raspberry Pi OS surfaces as its
+ * on-screen lightning-bolt icon. It is world-readable, so the engine reads it
+ * unprivileged.
+ *
+ * Returns:
+ *   - `true`  — under-voltage right now
+ *   - `false` — sensor present, rail OK
+ *   - `null`  — no `rpi_volt` device (non-Pi hardware) or hwmon unreadable;
+ *               "can't determine", deliberately distinct from `false` so callers
+ *               never raise a false alarm on x86 dev hosts.
+ *
+ * Note: this Yocto image ships no `vcgencmd`, so `in0_lcrit_alarm` is the only
+ * interface and it reports only the *live* state (no voltage value, no firmware
+ * sticky-bit history) — persistence is the caller's job (see the collector's
+ * debounce-and-latch below).
+ */
+export function readUndervoltage(hwmonRoot = '/sys/class/hwmon'): boolean | null {
+    let devices: string[];
+    try {
+        devices = fs.readdirSync(hwmonRoot);
+    } catch {
+        return null; // no hwmon subsystem
+    }
+    for (const dev of devices) {
+        const base = `${hwmonRoot}/${dev}`;
+        try {
+            if (fs.readFileSync(`${base}/name`, 'utf-8').trim() !== 'rpi_volt') continue;
+        } catch {
+            continue;
+        }
+        try {
+            return parseInt(fs.readFileSync(`${base}/in0_lcrit_alarm`, 'utf-8'), 10) === 1;
+        } catch {
+            return null; // device present but attribute unreadable
+        }
+    }
+    return null; // no rpi_volt device — not a Pi
+}
+
+/**
  * Periodically collects CPU, memory, and temperature stats.
  * Calls the provided callback with each sample.
  */
@@ -147,11 +198,36 @@ export class SystemStatsCollector {
     private prevCpuIdle = 0;
     private sampleCount = 0;
     private cachedBuildNumber: string | null = null;
+    // Under-voltage debounce + latch. `streak` counts consecutive under-voltage
+    // samples; the latch arms after 2 (~2-4s) so a lone boot-inrush blip doesn't
+    // permanently flag a healthy box, and stays armed until this process
+    // restarts (a genuine power fault sags repeatedly, so it re-arms in seconds
+    // after a restart if still faulty).
+    private undervoltageStreak = 0;
+    private undervoltageLatched = false;
 
     constructor(
         private onStats: (stats: SystemStats) => void,
         private intervalMs = 2000,
     ) {}
+
+    /**
+     * Debounce-then-latch step for the under-voltage flag. Feeds one reading
+     * (`true`/`false`/`null`) through the streak counter and the sticky latch,
+     * logs once when it arms, and returns whether the emitted stats should carry
+     * `undervoltage: true`. A `null` reading (no sensor) resets the streak like
+     * an OK read, so non-Pi hosts never latch. Extracted from the tick so the
+     * 2-consecutive boundary is unit-testable without driving the interval.
+     */
+    private updateUndervoltage(reading: boolean | null): boolean {
+        if (reading === true) this.undervoltageStreak++;
+        else this.undervoltageStreak = 0;
+        if (this.undervoltageStreak >= 2 && !this.undervoltageLatched) {
+            this.undervoltageLatched = true;
+            log.warn('Under-voltage detected — CPU is being throttled; check PSU/USB-C cable');
+        }
+        return this.undervoltageLatched;
+    }
 
     start(): void {
         if (this.timer) return;
@@ -180,6 +256,8 @@ export class SystemStatsCollector {
                     mem: memPercent,
                     temp: readCpuTemp(),
                 };
+
+                if (this.updateUndervoltage(readUndervoltage())) stats.undervoltage = true;
 
                 // Include IP + hostname + build on first sample and every 30 samples (~60s)
                 if (this.sampleCount % 30 === 0) {

--- a/packages/manager-ui/src/components/common/AppHeader.vue
+++ b/packages/manager-ui/src/components/common/AppHeader.vue
@@ -5,6 +5,8 @@ import { useSocketStore } from '@/stores/socket';
 import { useThemeStore } from '@/stores/theme';
 import { useEngineStore } from '@/stores/engines';
 import { statColorClass } from '@/composables/useStatColor';
+import { getLucideIcon } from '@/composables/useLucideIcons';
+import MrTooltip from '@/components/common/MrTooltip.vue';
 
 const route = useRoute();
 const socket = useSocketStore();
@@ -58,6 +60,13 @@ const activeEngine = computed(() => {
                     :class="statColorClass(activeEngine.system.temp, 70, 80)"
                     >{{ activeEngine.system.temp }}°C</span
                 >
+                <MrTooltip
+                    v-if="activeEngine.system.undervoltage"
+                    text="Under-voltage detected — the 5 V supply can't hold under load and the CPU is being throttled. Check the power supply and USB-C cable."
+                    width="w-64"
+                >
+                    <component :is="getLucideIcon('zap')" :size="14" class="text-warning" />
+                </MrTooltip>
             </div>
 
             <!-- IP -->

--- a/packages/manager-ui/src/components/common/EngineListItem.test.ts
+++ b/packages/manager-ui/src/components/common/EngineListItem.test.ts
@@ -55,6 +55,32 @@ describe('EngineListItem', () => {
         expect(wrapper.text()).toContain('60°C');
     });
 
+    it('shows the under-voltage warning icon when the flag is set', () => {
+        const wrapper = mount(EngineListItem, {
+            props: {
+                engine: makeEngine({
+                    online: true,
+                    system: { cpu: 33, mem: 50, temp: 60, undervoltage: true },
+                }),
+            },
+            global: { plugins: [withRouter()] },
+        });
+        expect(wrapper.find('[aria-label="Under-voltage detected"]').exists()).toBe(true);
+    });
+
+    it('has no under-voltage icon when the flag is unset', () => {
+        const wrapper = mount(EngineListItem, {
+            props: {
+                engine: makeEngine({
+                    online: true,
+                    system: { cpu: 33, mem: 50, temp: 60 },
+                }),
+            },
+            global: { plugins: [withRouter()] },
+        });
+        expect(wrapper.find('[aria-label="Under-voltage detected"]').exists()).toBe(false);
+    });
+
     it('hides system stats when offline', () => {
         const wrapper = mount(EngineListItem, {
             props: {

--- a/packages/manager-ui/src/components/common/EngineListItem.vue
+++ b/packages/manager-ui/src/components/common/EngineListItem.vue
@@ -2,6 +2,7 @@
 import { useRoute } from 'vue-router';
 import type { EngineState } from '@/stores/engines';
 import { statColorClass } from '@/composables/useStatColor';
+import { getLucideIcon } from '@/composables/useLucideIcons';
 
 defineProps<{ engine: EngineState }>();
 const emit = defineEmits<{ contextmenu: [ev: MouseEvent, engineId: string] }>();
@@ -45,6 +46,15 @@ const route = useRoute();
                 :class="statColorClass(engine.system.temp, 70, 80)"
             >
                 {{ engine.system.temp }}°C
+            </span>
+            <!-- Icon-only (no tooltip); aria-label carries meaning for a11y and
+                 is a stable hook independent of async icon resolution. -->
+            <span
+                v-if="engine.system.undervoltage"
+                class="text-warning shrink-0 inline-flex items-center"
+                aria-label="Under-voltage detected"
+            >
+                <component :is="getLucideIcon('zap')" :size="11" />
             </span>
         </div>
     </RouterLink>

--- a/packages/manager-ui/src/stores/engines.ts
+++ b/packages/manager-ui/src/stores/engines.ts
@@ -128,6 +128,7 @@ export interface SystemStats {
     cpu: number; // CPU usage %
     mem: number; // Memory usage %
     temp: number | null; // CPU temperature °C
+    undervoltage?: boolean; // Pi under-voltage warning (latched true; omitted otherwise)
     processCount?: number; // Spawned child processes
 }
 

--- a/packages/manager-ui/src/stores/socket.ts
+++ b/packages/manager-ui/src/stores/socket.ts
@@ -163,6 +163,7 @@ export const useSocketStore = defineStore('socket', () => {
                 cpu: number;
                 mem: number;
                 temp: number | null;
+                undervoltage?: boolean;
                 processCount?: number;
                 ip?: string;
                 ips?: string[];
@@ -174,6 +175,7 @@ export const useSocketStore = defineStore('socket', () => {
                     cpu: data.cpu,
                     mem: data.mem,
                     temp: data.temp,
+                    undervoltage: data.undervoltage,
                     processCount: data.processCount,
                 });
                 if (data.ip || data.ips || data.hostname || data.buildNumber) {


### PR DESCRIPTION
## What

Raspberry Pi firmware silently throttles the ARM cores when the 5 V rail sags, while `cpufreq` still reports full clock — so identical work can cost ~2.5× the CPU with no visible signal. This surfaces the condition in the dashboard instead of leaving it to manual SSH diagnosis.

## Changes

- **Engine:** `readUndervoltage()` reads the `rpi_volt` hwmon `in0_lcrit_alarm` flag (world-readable, so the engine reads it unprivileged; returns `null` on non-Pi hardware so x86 hosts never false-alarm). Same signal Raspberry Pi OS surfaces as its on-screen lightning-bolt icon.
- **Debounce + latch:** arm only after **2 consecutive** under-voltage samples, so a lone boot-inrush blip doesn't permanently flag a healthy box. The latch holds until the engine restarts; `log.warn` fires once on arm (breadcrumb for headless diagnosis).
- **Transport:** one `undervoltage` boolean threaded through `SystemStats` to the manager UI; the manager forwards it untouched (spreads the payload).
- **UI:** amber lightning-bolt (`zap`) badge in the header stats strip with an explanatory tooltip, and on each engine's sidebar row (icon-only, `aria-label` for a11y). The online dot is left as a pure connectivity indicator.

## Tests

11 new tests — engine `readUndervoltage` cases, the debounce/latch state machine (single sample doesn't arm, two consecutive do, stays latched after recovery, `null` resets the streak), and the sidebar badge render/absent cases. **1957 passing across 143 files**; the 2 failing are pre-existing macOS-only `unixfd` tests (`memfd_create`), unrelated to this change.

## Notes

- Degrades safely on non-Pi hardware: no `rpi_volt` device → `null` → field omitted → no badge.
- This image ships no `vcgencmd`, so the sysfs `in0_lcrit_alarm` is the only interface and it reports only the live state — the software latch is what provides persistence.
- The fix for a flagged box is physical (power supply / USB-C cable); the warning surfaces it, it doesn't cure it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
