### PR TITLE
fix(engine): strip mpegtsmux's stale streamheader at the bus egress

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -59,6 +59,7 @@ export {
     busTeeName,
     busEdgeSocketPath,
     busIngestSocketPath,
+    BUS_TS_CAPS,
     BUS_WATCHDOG_PREFIX,
 } from './plugins/busHelpers.js';
 export type { BusSrcOpts } from './plugins/busHelpers.js';

--- a/packages/engine/src/plugins/busHelpers.test.ts
+++ b/packages/engine/src/plugins/busHelpers.test.ts
@@ -6,6 +6,7 @@ import {
     busTeeName,
     busEdgeSocketPath,
     busIngestSocketPath,
+    BUS_TS_CAPS,
     BUS_WATCHDOG_PREFIX,
 } from './busHelpers.js';
 
@@ -113,8 +114,30 @@ describe('buildBusSink', () => {
         // pinned before the tee (unixfd consumers fail not-negotiated without
         // caps) and inherited by every branch.
         expect(buildBusSink(40001)).toBe(
-            'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
+            `capssetter caps="${BUS_TS_CAPS}" replace=true ! ` +
+                `capsfilter caps="${BUS_TS_CAPS}" ! ` +
                 'tee name=busout_40001 allow-not-linked=true',
         );
+    });
+
+    it('strips upstream caps fields BEFORE the tee, so no branch inherits them', () => {
+        // mpegtsmux publishes its first-generated PAT/PMT as a `streamheader`
+        // caps field. unixfd carries caps verbatim and srtsink replays that
+        // field to every new caller, so a stale snapshot (taken before the
+        // dynamic media pads linked — wrong PCR PID, missing streams) becomes
+        // every receiver's first PMT, permanently. `replace=true` is what drops
+        // it; a capsfilter cannot, because caps intersection unions fields.
+        const sink = buildBusSink(40001);
+        expect(sink).toContain('capssetter');
+        expect(sink).toContain('replace=true');
+        expect(sink.indexOf('capssetter')).toBeLessThan(sink.indexOf('tee name='));
+    });
+
+    it('publishes the same caps as the unixfd-fanout sidecar', () => {
+        // Both producer paths (GStreamer tee here, unixfd-fanout.py --caps for
+        // non-GStreamer producers) must put IDENTICAL caps on the wire — a
+        // consumer cannot tell which produced its edge.
+        expect(BUS_TS_CAPS).toBe('video/mpegts, systemstream=(boolean)true, packetsize=(int)188');
+        expect(buildBusSink(40001)).toContain(BUS_TS_CAPS);
     });
 });

--- a/packages/engine/src/plugins/busHelpers.ts
+++ b/packages/engine/src/plugins/busHelpers.ts
@@ -22,6 +22,16 @@
  */
 
 /**
+ * The caps EVERY bus producer publishes — identity, not a hint. unixfd carries
+ * caps across the socket and `tsdemux` rejects caps-less buffers, so both
+ * producer paths must publish exactly this and nothing more: the GStreamer
+ * egress (`buildBusSink`) and the `unixfd-fanout.py` sidecar (`--caps`).
+ *
+ * "Nothing more" is load-bearing — see the `capssetter` note in `buildBusSink`.
+ */
+export const BUS_TS_CAPS = 'video/mpegts, systemstream=(boolean)true, packetsize=(int)188';
+
+/**
  * Channel-level socket path for one bus channel. Used only as the fallback
  * socket for a channel with no per-consumer fan-out; the live path is
  * `busEdgeSocketPath` (one socket per consumer edge).
@@ -151,7 +161,7 @@ export function buildBusSrc(opts: BusSrcOpts): string {
 
 /**
  * Bus egress (fan-out point) for a producer:
- *   capsfilter (pinned TS caps) ! tee busout_<port> allow-not-linked=true
+ *   capssetter (replace) ! capsfilter (pinned TS caps) ! tee busout_<port>
  *
  * The actual `unixfdsink` branches are attached one per consumer at runtime
  * via `bus_attach` (`gst-pipeline-runner.py`), each
@@ -162,13 +172,27 @@ export function buildBusSrc(opts: BusSrcOpts): string {
  *
  * `allow-not-linked=true` lets the producer run with zero consumers attached
  * (buffers dropped at the tee) — consumers wire in later without a producer
- * rebuild. The capsfilter pins TS caps (unixfd transports caps; tsdemux
- * rejects caps-less buffers), inherited by every attached branch. The tee's
- * sink pad is the throughput-probe target (`busTeeName`).
+ * rebuild. The tee's sink pad is the throughput-probe target (`busTeeName`).
+ *
+ * The `capssetter … replace=true` DROPS incoming caps fields, and exists for
+ * exactly one of them: `mpegtsmux` publishes the PAT/PMT it generated FIRST
+ * into a `streamheader` caps field. That snapshot is taken before the
+ * dynamically-linked media pads exist (mux pads are requested at tsdemux
+ * pad-added), so it can name the wrong PCR PID and omit whole streams — and it
+ * is never refreshed when the live PMT is corrected. unixfd carries caps
+ * verbatim across the socket, so the stale header reaches consumers, and
+ * `srtsink` replays it to every newly connected caller for the pipeline's
+ * lifetime: a receiver's FIRST PMT was a snapshot of a pipeline that no longer
+ * exists. Stripping costs a new caller nothing — real PSI repeats ~10×/s.
+ * A capsfilter alone cannot do this: caps intersection is a field UNION, so it
+ * preserves upstream fields it does not mention. It stays behind the capssetter
+ * as the negotiation guard (a producer that somehow emits non-TS caps must
+ * still fail loudly rather than publish them).
  */
 export function buildBusSink(port: number): string {
     return (
-        'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
+        `capssetter caps="${BUS_TS_CAPS}" replace=true ! ` +
+        `capsfilter caps="${BUS_TS_CAPS}" ! ` +
         `tee name=${busTeeName(port)} allow-not-linked=true`
     );
 }

--- a/plugins/audio-encoder/engine/AudioEncoderModule.test.ts
+++ b/plugins/audio-encoder/engine/AudioEncoderModule.test.ts
@@ -32,7 +32,7 @@ describe('AudioEncoderModule.buildPipeline', () => {
         expect(desc.pipeline).toContain('pulsesrc device=MR_PW_enc-1.monitor');
         expect(desc.pipeline).toContain('opusenc bitrate=128000');
         expect(desc.pipeline).toContain(
-            'mpegtsmux latency=0 alignment=7 ! capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! tee name=busout_41000 allow-not-linked=true',
+            'mpegtsmux latency=0 alignment=7 ! capssetter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" replace=true ! capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! tee name=busout_41000 allow-not-linked=true',
         );
         expect(desc.pipeline).not.toContain('udpsink');
     });

--- a/plugins/audio-input-302m/engine/AudioInput302mModule.test.ts
+++ b/plugins/audio-input-302m/engine/AudioInput302mModule.test.ts
@@ -36,7 +36,7 @@ describe('AudioInput302mModule.buildPipeline', () => {
             'audio/x-raw,format=S32LE,rate=48000,channels=2 ! avenc_s302m strict=experimental ! mpegtsmux latency=0 alignment=7',
         );
         expect(desc!.pipeline).toContain(
-            'mpegtsmux latency=0 alignment=7 ! capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! tee name=busout_41000 allow-not-linked=true',
+            'mpegtsmux latency=0 alignment=7 ! capssetter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" replace=true ! capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! tee name=busout_41000 allow-not-linked=true',
         );
         expect(desc!.restartOnError).toBe(true);
         expect(module.setStatusData).toHaveBeenCalledWith('bus', { channel: 41000 });

--- a/plugins/hls-player/engine/HlsPlayerModule.ts
+++ b/plugins/hls-player/engine/HlsPlayerModule.ts
@@ -1,4 +1,5 @@
 import {
+    BUS_TS_CAPS,
     GstPluginBase,
     UnixFdFanoutController,
     busIngestSocketPath,
@@ -11,9 +12,6 @@ import type { AlternateRendition } from 'hls-pipe';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { resolutionCapBitrateBps, resolveQuality } from './runnerOptions.js';
-
-/** Bus wire caps — identical to `buildBusSink`'s capsfilter. */
-const BUS_TS_CAPS = 'video/mpegts, systemstream=(boolean)true, packetsize=(int)188';
 
 /**
  * Locate the compiled runner. `__dirname` is `dist/` in production, but the

--- a/plugins/mpegts-muxer/engine/MpegTsMuxerModule.test.ts
+++ b/plugins/mpegts-muxer/engine/MpegTsMuxerModule.test.ts
@@ -185,7 +185,11 @@ describe('mpegtsMuxerPipeline helpers', () => {
                 alignment: 7,
             });
             const p = result!.pipeline;
-            expect(p).toMatch(/mpegtsmux name=mux[^!]+! capsfilter caps="video\/mpegts/);
+            // capssetter is the first element of the bus egress (caps-only, no
+            // buffering) — the point of the assertion is that nothing that can
+            // DROP sits between the mux and the tee.
+            expect(p).toMatch(/mpegtsmux name=mux[^!]+! capssetter caps="video\/mpegts/);
+            expect(p).not.toMatch(/mpegtsmux name=mux[^!]+! queue/);
         });
         it('emits one demux branch per input plus a single mpegtsmux ! bus-egress chain and per-media link rules', () => {
             const result = buildPipeline({
@@ -199,7 +203,8 @@ describe('mpegtsMuxerPipeline helpers', () => {
             expect(result).not.toBeNull();
             expect(result!.pipeline).toContain('mpegtsmux name=mux latency=1200000000 min-upstream-latency=1200000000 alignment=7');
             expect(result!.pipeline).toContain(
-                'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
+                'capssetter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" replace=true ! ' +
+                    'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
                     'tee name=busout_40010 allow-not-linked=true',
             );
             expect(result!.pipeline.match(/tsdemux latency=0 name=demux_/g)).toHaveLength(2);

--- a/plugins/video-encoder/engine/VideoEncoderModule.test.ts
+++ b/plugins/video-encoder/engine/VideoEncoderModule.test.ts
@@ -313,11 +313,14 @@ describe('VideoEncoderModule', () => {
             expect(desc!.pipeline).toContain('v4l2src device=/dev/video-nonexistent-for-test');
             expect(desc!.pipeline).toContain('v4l2h264enc name=venc0');
             expect(desc!.pipeline).toContain('mpegtsmux name=mux latency=0 alignment=7');
-            // Bus egress: pinned TS caps + per-consumer fan-out tee. The
-            // unixfdsink branches are attached at runtime by the coordinator;
-            // allow-not-linked lets the encoder run with zero consumers.
+            // Bus egress: stripped + pinned TS caps, then a per-consumer
+            // fan-out tee. The unixfdsink branches are attached at runtime by
+            // the coordinator; allow-not-linked lets the encoder run with zero
+            // consumers. The capssetter drops mpegtsmux's stale `streamheader`
+            // before any branch (and any srtsink) can inherit it.
             expect(desc!.pipeline).toContain(
-                'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
+                'capssetter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" replace=true ! ' +
+                    'capsfilter caps="video/mpegts, systemstream=(boolean)true, packetsize=(int)188" ! ' +
                     'tee name=busout_5000 allow-not-linked=true',
             );
             expect(desc!.pipeline).not.toContain('udpsink');
@@ -380,7 +383,10 @@ describe('VideoEncoderModule', () => {
                 bitrate: 4000,
                 keyframeInterval: 60,
             });
-            expect(desc!.pipeline).toMatch(/mpegtsmux name=mux[^!]+! capsfilter/);
+            // capssetter opens the bus egress (caps-only, no buffering) — what
+            // must not appear between mux and tee is anything that can DROP.
+            expect(desc!.pipeline).toMatch(/mpegtsmux name=mux[^!]+! capssetter/);
+            expect(desc!.pipeline).not.toMatch(/mpegtsmux name=mux[^!]+! queue/);
         });
 
         it('returns null + sets health warning when no device is configured', () => {


### PR DESCRIPTION
## The bug

A receiver connecting to any GStreamer bus producer's SRT output gets a **stale PAT/PMT as its first packets** — a snapshot of a pipeline that no longer exists.

Observed on a live muxer output as a `version=0` PMT listing **no video** and pinning **PCR to the KLV metadata PID**, prefixed to a stream whose PCR showed it had been running over an hour. Two independent connections, identical result. The live PMT a few packets later was correct (`version=2`, PCR on the video PID).

Symptom for operators: a receiver shows a private stream and no audio for a while before the codec resolves. Worse, a receiver that latches the cached header clocks the program off the ~50 ms software-timed carousel instead of the media — the exact failure mode that retired the carousel once already, so this surfaces as audio drops rather than a cosmetic label.

## The chain

1. `mpegtsmux` writes the PSI it generates **first** into a `streamheader` caps field (`"setting %u packets into streamheader"`).
2. That first PSI is generated before the dynamically-linked media pads exist — mux pads are requested at `tsdemux` pad-added — so `prog-map`'s `PCR_1=sink_256` names a pad that isn't there yet and `mpegtsmux` falls back to whatever pad is. The KLV appsrc is static in the launch string, so it always wins that race.
3. `unixfdsink`/`unixfdsrc` carry caps verbatim, so the field crosses the process boundary intact.
4. `srtsink` replays `streamheader` to every newly connected caller, forever.

**The PCR-pin fix this builds on is intact and working** — the live PMT is correct. What leaked is a second, never-refreshed copy of the PMT that the pin could not reach.

## The fix

`buildBusSink` now opens with `capssetter … replace=true`, which drops incoming caps fields.

A capsfilter cannot do this — caps intersection is a field **union**, so it preserves fields it doesn't mention. That's why the existing capsfilter never stopped it. The capsfilter stays behind the capssetter as the negotiation guard.

Also exports `BUS_TS_CAPS` from busHelpers and reuses it in the hls-player's `unixfd-fanout` sidecar, which previously duplicated the literal with a "keep in sync" comment. Worth noting: the fanout path was **already** clean — it publishes plain `video/mpegts` caps — which is exactly why only GStreamer producers leaked the header. The two producer paths now provably publish identical caps.

In-band PSI is untouched. A new caller waits for the next periodic PMT instead of getting a wrong one; measured PSI repetition is ~10x/s.

## Verification

On target hardware (GStreamer 1.28.2, aarch64), with a producer mirroring the muxer's shape across a real unixfd hop into a separate consumer process:

- **before** — `streamheader` arrives in the consumer process off the bus
- **after** — it does not
- **after, in-band** — PAT + PMT still ~10x/s, PCR correctly pinned to the video PID, PES flowing on both PIDs

`1934 tests passing across 143 files`, including 3 new assertions on the egress shape. The 2 remaining failures in `unixfdFanout.test.ts` are **pre-existing** — verified failing on the base commit — as that test drives the Linux memfd/SCM_RIGHTS protocol and can't run on macOS.

### Not yet done

The patched engine build has **not** been run end-to-end on a device: `/opt/media-router` is root-owned on the test box and the available credentials have no write access there. The GStreamer-level behaviour is verified on the real target as described above; a device-level run is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)