### PR TITLE
fix(engine): hold hardware PipeWire sinks at unity gain

### DIFF
--- a/docs/adr/0006-hardware-sinks-held-at-unity-gain.md
+++ b/docs/adr/0006-hardware-sinks-held-at-unity-gain.md
@@ -1,0 +1,31 @@
+# ADR-0006: Hardware PipeWire sinks are held at unity gain
+
+Gain staging lives in software. Hardware PipeWire sinks are forced to unity
+(100% on every channel, raw `PA_VOLUME_NORM` = 65536) whenever the `audio-sink`
+device provider polls, and any drift is corrected on the next poll.
+
+## Why
+
+There were two gain stages in series and only one of them was visible. Modules
+attenuate on their own `MR_PW_*` remap-sink or in GStreamer, which is what the
+UI volume control drives. The underlying hardware sink carried a second,
+invisible multiplier: WirePlumber restores whatever level a device was last
+left at, and a fresh USB interface commonly comes up at 40% / -23.9 dB. A
+module showing 100% was really outputting -23.9 dB, with nothing in the UI to
+explain it — a broadcast system must not silently attenuate.
+
+Correcting on detection (rather than once at boot) covers hot-plug, engine
+restarts, and anything that changes the level behind our back (`alsamixer`, a
+desktop mixer, a WirePlumber restore after profile switch).
+
+## Consequences
+
+- Device volume is no longer adjustable outside Media Router — an operator
+  turning a sink down with `pactl` or `alsamixer` will see it snap back within
+  one poll. That is the intent: one authoritative gain stage.
+- `MR_PW_*` devices are exempt (they never reach the normalizer — `listDevices`
+  filters them), so per-module software volume is untouched.
+- Scoped to sinks. Hardware sources are left alone for now; input gain on a
+  capture device is often a real analogue trim rather than a stale restore.
+- Implementation: `SinkVolumeNormalizer`, invoked from
+  `registerPipeWireDeviceProvider` for `direction: 'sink'`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ the old one `superseded by ADR-NNNN`). Number = highest existing + 1.
 | [0002](0002-engine-core-stays-in-packages-engine.md) | Engine orchestration core stays in `packages/engine`; plugins depend on the engine, never the reverse (one recorded name/path-only exception) |
 | [0003](0003-scoped-native-resolution-and-namespaced-install.md) | Native/python resolution is scoped to the requesting plugin; installs are namespaced under `/usr/libexec/media-router/<plugin>/`; ambiguity fails loud |
 | [0004](0004-out-of-repo-plugins-injected-at-image-build.md) | Product-specific plugins may live in the consuming product's repo (under `media-router-plugin/`) and be injected into `plugins/` at image build |
+| [0006](0006-hardware-sinks-held-at-unity-gain.md) | Hardware PipeWire sinks are forced to unity gain on detection; all attenuation happens in software (`MR_PW_*` nodes / GStreamer) |

--- a/packages/engine/src/audio/AudioDeviceOps.test.ts
+++ b/packages/engine/src/audio/AudioDeviceOps.test.ts
@@ -3,6 +3,8 @@ import {
     parseDeviceBlock,
     parseDeviceChannels,
     parseDeviceSampleRate,
+    parseDeviceVolumes,
+    PA_VOLUME_NORM,
 } from './AudioDeviceOps.js';
 
 describe('parseDeviceChannels', () => {
@@ -46,6 +48,41 @@ describe('parseDeviceSampleRate', () => {
     });
 });
 
+describe('parseDeviceVolumes', () => {
+    // Verbatim from `pactl list sinks` on a Shure MVX2U sitting at the
+    // restored 40% that this fix exists to correct.
+    const shure = [
+        '\tMute: no',
+        '\tVolume: front-left: 26214 /  40% / -23.88 dB,   front-right: 26214 /  40% / -23.88 dB',
+        '\t        balance 0.00',
+        '\tBase Volume: 65536 / 100% / 0.00 dB',
+    ].join('\n');
+
+    it('reads one raw value per channel', () => {
+        expect(parseDeviceVolumes(shure)).toEqual([26214, 26214]);
+    });
+    it('does not mistake `Base Volume:` for the current volume', () => {
+        // Base Volume is always 65536; reading it would make an attenuated
+        // device look like it is already at unity and skip the reset.
+        expect(parseDeviceVolumes('\tBase Volume: 65536 / 100% / 0.00 dB')).toEqual([]);
+    });
+    it('reads a mono device as a single channel', () => {
+        expect(parseDeviceVolumes('\tVolume: mono: 65536 / 100% / 0.00 dB')).toEqual([
+            PA_VOLUME_NORM,
+        ]);
+    });
+    it('reads all six channels of a surround device', () => {
+        const line =
+            '\tVolume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB,   ' +
+            'front-center: 65536 / 100% / 0.00 dB,   lfe: 65536 / 100% / 0.00 dB,   ' +
+            'rear-left: 65536 / 100% / 0.00 dB,   rear-right: 65536 / 100% / 0.00 dB';
+        expect(parseDeviceVolumes(line)).toHaveLength(6);
+    });
+    it('returns an empty array when the block has no volume line', () => {
+        expect(parseDeviceVolumes('Name: alsa_output.foo\nChannel Map: mono')).toEqual([]);
+    });
+});
+
 describe('parseDeviceBlock', () => {
     it('returns null for blocks without a `Name:` field (e.g. blank trailing block)', () => {
         expect(parseDeviceBlock('', 'source')).toBeNull();
@@ -69,6 +106,14 @@ describe('parseDeviceBlock', () => {
         expect(dev!.channels).toBe(1);
         expect(dev!.sampleRate).toBeUndefined();
         expect(dev!.description).toBe('USB PnP Mono');
+    });
+    it('carries per-channel volumes through so the normalizer can act on them', () => {
+        const block = [
+            'Name: alsa_output.usb-shure',
+            'Channel Map: front-left,front-right',
+            '\tVolume: front-left: 26214 /  40% / -23.88 dB,   front-right: 26214 /  40% / -23.88 dB',
+        ].join('\n');
+        expect(parseDeviceBlock(block, 'sink')!.volumes).toEqual([26214, 26214]);
     });
     it('falls back to `name` for description when missing', () => {
         const block = `Name: alsa_input.foo\nChannel Map: mono`;

--- a/packages/engine/src/audio/AudioDeviceOps.ts
+++ b/packages/engine/src/audio/AudioDeviceOps.ts
@@ -5,6 +5,14 @@ import { MR_PW_PREFIX, type AudioDevice } from './PipeWireManager.js';
 const log = createLogger('AudioDeviceOps');
 
 /**
+ * PulseAudio's unity-gain reference (`PA_VOLUME_NORM`) — the raw value pactl
+ * renders as `100% / 0.00 dB`. Volumes are compared and set in raw units
+ * rather than percent because pactl rounds the percentage it prints (65530
+ * also renders as `100%`), and we want an exact, idempotent target.
+ */
+export const PA_VOLUME_NORM = 65536;
+
+/**
  * Parse the channel count from a `pactl list sources/sinks` block, preferring
  * `Channel Map:` over `Sample Specification:`.
  *
@@ -46,6 +54,25 @@ export function parseDeviceSampleRate(block: string): number | undefined {
 }
 
 /**
+ * Parse the per-channel raw volumes from a `pactl list` block.
+ *
+ * The line looks like:
+ *   `Volume: front-left: 26214 /  40% / -23.88 dB,   front-right: 26214 / ...`
+ * or, for a mono device, `Volume: mono: 65536 / 100% / 0.00 dB`.
+ *
+ * The `^[ \t]*` anchor matters: it keeps `Base Volume:` (a different line,
+ * always at 65536) from being mistaken for the current volume.
+ *
+ * Returns an empty array when the block has no volume line — pactl omits it
+ * for some virtual devices, and "unknown" must not be read as "attenuated".
+ */
+export function parseDeviceVolumes(block: string): number[] {
+    const match = block.match(/^[ \t]*Volume:[ \t]*(.+)$/m);
+    if (!match) return [];
+    return [...match[1].matchAll(/:\s*(\d+)\s*\//g)].map((m) => parseInt(m[1], 10));
+}
+
+/**
  * Parse one `pactl list sources/sinks` block into an `AudioDevice`. Returns
  * `null` only when the block has no `Name:` field (i.e. it's not a real
  * device entry — e.g. the trailing blank between blocks).
@@ -73,6 +100,7 @@ export function parseDeviceBlock(
         direction,
         channels: parseDeviceChannels(block),
         sampleRate: parseDeviceSampleRate(block),
+        volumes: parseDeviceVolumes(block),
     };
 }
 

--- a/packages/engine/src/audio/PipeWireManager.ts
+++ b/packages/engine/src/audio/PipeWireManager.ts
@@ -9,6 +9,7 @@ import {
     getLinks as _getLinks,
 } from './PwLinkOps.js';
 import { AudioDeviceOps } from './AudioDeviceOps.js';
+import { SinkVolumeNormalizer } from './SinkVolumeNormalizer.js';
 
 const log = createLogger('PipeWireManager');
 
@@ -22,6 +23,9 @@ export interface AudioDevice {
     direction: 'source' | 'sink';
     channels?: number;
     sampleRate?: number;
+    /** Raw per-channel volumes (`PA_VOLUME_NORM` = 65536 = unity). Empty when
+     *  pactl reported no volume line for the device. */
+    volumes?: number[];
 }
 
 /**
@@ -36,12 +40,14 @@ export interface AudioDevice {
 export class PipeWireManager {
     private paQueue: PaCommandQueue;
     private deviceOps: AudioDeviceOps;
+    private sinkVolumes: SinkVolumeNormalizer;
     /** Ownership tracking: ownerId → Set of PA module IDs */
     private ownership = new Map<string, Set<number>>();
 
     constructor(paQueue?: PaCommandQueue) {
         this.paQueue = paQueue ?? new PaCommandQueue();
         this.deviceOps = new AudioDeviceOps(this.paQueue);
+        this.sinkVolumes = new SinkVolumeNormalizer(this.paQueue);
     }
 
     /** Track a PA module ID as owned by a specific owner. */
@@ -314,6 +320,14 @@ export class PipeWireManager {
 
     async setSinkVolume(device: string, percent: number): Promise<void> {
         return this.deviceOps.setSinkVolume(device, percent);
+    }
+
+    /**
+     * Hold hardware sinks at unity gain — call with a fresh `listDevices()`
+     * result (the device-provider poll does this). Fire-and-forget.
+     */
+    normalizeSinkVolumes(devices: AudioDevice[]): void {
+        this.sinkVolumes.normalize(devices);
     }
 
     // --- Device enumeration (delegated to AudioDeviceOps) ---

--- a/packages/engine/src/audio/SinkVolumeNormalizer.test.ts
+++ b/packages/engine/src/audio/SinkVolumeNormalizer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PaCommandQueue } from './PaCommandQueue.js';
+import { PA_VOLUME_NORM } from './AudioDeviceOps.js';
+import type { AudioDevice } from './PipeWireManager.js';
+import { SinkVolumeNormalizer } from './SinkVolumeNormalizer.js';
+
+function makeQueue(impl: () => Promise<string> = () => Promise.resolve('')) {
+    const exec = vi.fn(impl);
+    return { queue: { exec } as unknown as PaCommandQueue, exec };
+}
+
+function dev(over: Partial<AudioDevice>): AudioDevice {
+    return {
+        id: 0,
+        name: 'alsa_output.usb-shure',
+        description: 'Shure MVX2U',
+        direction: 'sink',
+        volumes: [PA_VOLUME_NORM, PA_VOLUME_NORM],
+        ...over,
+    };
+}
+
+describe('SinkVolumeNormalizer', () => {
+    it('resets an attenuated sink to unity in raw PA units', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([dev({ volumes: [26214, 26214] })]);
+        expect(exec).toHaveBeenCalledWith(['set-sink-volume', 'alsa_output.usb-shure', '65536']);
+    });
+
+    it('leaves a sink already at unity alone', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([dev({})]);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('resets when only one channel is off unity — a balance offset attenuates too', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([dev({ volumes: [PA_VOLUME_NORM, 26214] })]);
+        expect(exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets a sink boosted above unity — software owns gain in both directions', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([dev({ volumes: [98304, 98304] })]);
+        expect(exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores sources — the fix is scoped to sinks', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([
+            dev({ direction: 'source', volumes: [26214, 26214] }),
+        ]);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('ignores devices with no parsed volume rather than assuming attenuation', () => {
+        const { queue, exec } = makeQueue();
+        const norm = new SinkVolumeNormalizer(queue);
+        norm.normalize([dev({ volumes: [] }), dev({ name: 'b', volumes: undefined })]);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('does not stack a second reset while the first is still in flight', () => {
+        let release!: () => void;
+        const { queue, exec } = makeQueue(() => new Promise<string>((r) => {
+            release = () => r('');
+        }));
+        const norm = new SinkVolumeNormalizer(queue);
+        const devices = [dev({ volumes: [26214, 26214] })];
+        norm.normalize(devices);
+        norm.normalize(devices);
+        expect(exec).toHaveBeenCalledTimes(1);
+        release();
+    });
+
+    it('retries on the next poll once a failed reset has settled', async () => {
+        const { queue, exec } = makeQueue(() => Promise.reject(new Error('pactl failed')));
+        const norm = new SinkVolumeNormalizer(queue);
+        const devices = [dev({ volumes: [26214, 26214] })];
+        norm.normalize(devices);
+        await vi.waitFor(() => expect(exec).toHaveBeenCalledTimes(1));
+        // Let the rejection handler clear the in-flight marker.
+        await new Promise((r) => setTimeout(r, 0));
+        norm.normalize(devices);
+        expect(exec).toHaveBeenCalledTimes(2);
+    });
+
+    it('normalizes every attenuated sink in one pass', () => {
+        const { queue, exec } = makeQueue();
+        new SinkVolumeNormalizer(queue).normalize([
+            dev({ name: 'a', volumes: [26214, 26214] }),
+            dev({ name: 'b', volumes: [PA_VOLUME_NORM, PA_VOLUME_NORM] }),
+            dev({ name: 'c', volumes: [32768] }),
+        ]);
+        expect(exec.mock.calls.map((c) => c[0][1])).toEqual(['a', 'c']);
+    });
+});

--- a/packages/engine/src/audio/SinkVolumeNormalizer.ts
+++ b/packages/engine/src/audio/SinkVolumeNormalizer.ts
@@ -1,0 +1,50 @@
+import { createLogger } from '@media-router/shared-types';
+import type { PaCommandQueue } from './PaCommandQueue.js';
+import { PA_VOLUME_NORM } from './AudioDeviceOps.js';
+import type { AudioDevice } from './PipeWireManager.js';
+
+const log = createLogger('SinkVolumeNormalizer');
+
+/**
+ * Holds every hardware sink at unity gain (100% on all channels).
+ *
+ * Attenuation belongs in software — modules set their own `MR_PW_*`
+ * remap-sink volume or attenuate in GStreamer. A hardware sink carrying an
+ * extra gain stage of its own multiplies with that, and WirePlumber restores
+ * whatever level a device was last left at (commonly 40% / -23.9 dB on a
+ * fresh USB interface), which shows up as unusably quiet headphone output
+ * with no indication in the UI.
+ *
+ * `MR_PW_*` devices never reach this class — `parseDeviceBlock` filters them
+ * out of `listDevices()` — so the per-module software volume is untouched.
+ */
+export class SinkVolumeNormalizer {
+    /** Devices with a reset already queued, so a re-poll doesn't stack more. */
+    private inFlight = new Set<string>();
+
+    constructor(private paQueue: PaCommandQueue) {}
+
+    /**
+     * Reset any sink in `devices` that isn't at unity. Fire-and-forget: the
+     * caller is the device-provider poll, which must stay synchronous, and a
+     * failed reset is retried on the next poll anyway.
+     */
+    normalize(devices: AudioDevice[]): void {
+        for (const dev of devices) {
+            if (dev.direction !== 'sink') continue;
+            // No volume line parsed — don't guess, and don't treat unknown
+            // as attenuated (that would spam pactl every poll).
+            if (!dev.volumes?.length) continue;
+            if (dev.volumes.every((v) => v === PA_VOLUME_NORM)) continue;
+            if (this.inFlight.has(dev.name)) continue;
+
+            this.inFlight.add(dev.name);
+            const was = dev.volumes;
+            this.paQueue
+                .exec(['set-sink-volume', dev.name, String(PA_VOLUME_NORM)])
+                .then(() => log.info({ device: dev.name, was }, 'Reset sink to unity gain'))
+                .catch((err) => log.warn({ device: dev.name, err }, 'Failed to reset sink to unity gain'))
+                .finally(() => this.inFlight.delete(dev.name));
+        }
+    }
+}

--- a/packages/engine/src/system/pipeWireDeviceProvider.test.ts
+++ b/packages/engine/src/system/pipeWireDeviceProvider.test.ts
@@ -8,13 +8,15 @@ function makeServices(devices: Array<Record<string, unknown>>) {
     const register = vi.fn((p: DeviceProvider) => {
         registered = p;
     });
+    const normalizeSinkVolumes = vi.fn();
     const services = {
         pipeWire: {
             listDevices: vi.fn(() => devices),
+            normalizeSinkVolumes,
         },
         deviceProviders: { register },
     } as unknown as EngineServices;
-    return { services, register, getRegistered: () => registered };
+    return { services, register, normalizeSinkVolumes, getRegistered: () => registered };
 }
 
 describe('registerPipeWireDeviceProvider', () => {
@@ -69,6 +71,35 @@ describe('registerPipeWireDeviceProvider', () => {
         registerPipeWireDeviceProvider(services, { type: 'audio-source', direction: 'source' });
         const list = getRegistered()!.list() as Array<{ label: string }>;
         expect(list[0].label).toBe('unnamed (1ch, 44100Hz)');
+    });
+
+    it('normalizes sink volumes on every poll, with the unfiltered device list', () => {
+        const devices = [
+            { name: 'spk', direction: 'sink', description: 'Speakers', volumes: [26214, 26214] },
+            { name: 'mic', direction: 'source', description: 'Mic', volumes: [65536] },
+        ];
+        const { services, normalizeSinkVolumes, getRegistered } = makeServices(devices);
+        registerPipeWireDeviceProvider(services, { type: 'audio-sink', direction: 'sink' });
+        getRegistered()!.list();
+        expect(normalizeSinkVolumes).toHaveBeenCalledWith(devices);
+    });
+
+    it('does not normalize from the source provider — sinks are corrected once, not twice', () => {
+        const { services, normalizeSinkVolumes, getRegistered } = makeServices([
+            { name: 'mic', direction: 'source', description: 'Mic' },
+        ]);
+        registerPipeWireDeviceProvider(services, { type: 'audio-source', direction: 'source' });
+        getRegistered()!.list();
+        expect(normalizeSinkVolumes).not.toHaveBeenCalled();
+    });
+
+    it('keeps volume out of `meta` so the registry diff does not spam deviceList', () => {
+        const { services, getRegistered } = makeServices([
+            { name: 'spk', direction: 'sink', description: 'Speakers', channels: 2, sampleRate: 48000, volumes: [26214, 26214] },
+        ]);
+        registerPipeWireDeviceProvider(services, { type: 'audio-sink', direction: 'sink' });
+        const list = getRegistered()!.list() as Array<{ meta: Record<string, unknown> }>;
+        expect(list[0].meta).toEqual({ direction: 'sink', channels: 2, sampleRate: 48000 });
     });
 
     it('renders `?` placeholders when channel/sampleRate are missing', () => {

--- a/packages/engine/src/system/pipeWireDeviceProvider.ts
+++ b/packages/engine/src/system/pipeWireDeviceProvider.ts
@@ -18,6 +18,11 @@ export interface PipeWireDeviceProviderOptions {
  *
  * Replaces the boilerplate that `audio-input` and `audio-output` previously
  * duplicated — call from a plugin's static `registerServices(services)` hook.
+ *
+ * The sink poll doubles as the detection point for volume normalisation: any
+ * hardware sink not at unity gain is reset, so a device is corrected as soon
+ * as it is enumerated and again if something (WirePlumber restore, alsamixer)
+ * pulls it back down. See `SinkVolumeNormalizer`.
  */
 export function registerPipeWireDeviceProvider(
     services: EngineServices,
@@ -27,20 +32,25 @@ export function registerPipeWireDeviceProvider(
     services.deviceProviders.register({
         type,
         pollMs,
-        list: () =>
-            services.pipeWire
-                .listDevices()
+        list: () => {
+            const devices = services.pipeWire.listDevices();
+            if (direction === 'sink') services.pipeWire.normalizeSinkVolumes(devices);
+            return devices
                 .filter((d) => d.direction === direction)
                 .map(
                     (d): Device => ({
                         name: d.name,
                         label: `${d.description || d.name} (${d.channels ?? '?'}ch, ${d.sampleRate ?? '?'}Hz)`,
+                        // Deliberately no volume here — the registry diffs this
+                        // JSON to decide when to emit `deviceList`, and a
+                        // fluctuating volume would spam the manager.
                         meta: {
                             direction: d.direction,
                             channels: d.channels,
                             sampleRate: d.sampleRate,
                         },
                     }),
-                ),
+                );
+        },
     });
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -932,6 +932,13 @@ export class AudioInputModule extends GstPluginBase {
 }
 ```
 
+A `direction: 'sink'` provider also drives **hardware sink volume normalisation**: on
+every poll the engine resets any non-`MR_PW_*` sink that isn't at unity gain back to
+100% on all channels. Gain staging is a software concern — attenuate on your own
+`MR_PW_*` node or in GStreamer, never by turning a hardware sink down, or your
+attenuation will stack on top of whatever WirePlumber restored (commonly 40%). See
+[ADR-0006](../docs/adr/0006-hardware-sinks-held-at-unity-gain.md).
+
 For non-PipeWire devices (V4L2, DRM, custom hardware), register a raw provider:
 
 ```typescript


### PR DESCRIPTION
## Problem

There were two gain stages in series and only one of them was visible.

Modules attenuate on their own `MR_PW_*` remap-sink or in GStreamer — that's what the UI volume control drives. The underlying hardware sink carried a second, invisible multiplier: WirePlumber restores whatever level a device was last left at, and a fresh USB audio interface commonly comes up at **40% / -23.9 dB**. A module showing 100% was really outputting -23.9 dB, with nothing in the UI to explain it.

For a broadcast system, silently attenuating is not acceptable.

## Fix

Gain staging lives in software only. Hardware PipeWire sinks are forced to unity (100% on every channel).

- **`SinkVolumeNormalizer`** (new, 48 lines) — resets any sink whose channels aren't all at `PA_VOLUME_NORM` via `pactl set-sink-volume <dev> 65536`. A single value applies to all channels, so it clears balance offsets too.
- **`parseDeviceVolumes`** in `AudioDeviceOps` — pulls raw per-channel volumes out of the `pactl list sinks` block the engine *already* parses every poll. `AudioDevice` gains `volumes?: number[]`.
- **Hook** — `registerPipeWireDeviceProvider` calls the normalizer when `direction === 'sink'`, reusing the existing 2 s poll. No extra `pactl` calls.

### Three details that make it behave

1. **`MR_PW_*` devices are exempt for free** — `parseDeviceBlock` already filters them out of `listDevices()`, so per-module software volume is untouched. Only real hardware sinks get pinned.
2. **Continuous, not once-at-boot** — covers hot-plug, engine restart, and anything changing the level behind our back (`alsamixer`, a desktop mixer, a WirePlumber restore after profile switch). A boot-only fix would drift back.
3. **Raw PA units, not percent** — `pactl` rounds 65530 to `100%`, so a percent comparison would skip near-unity drift. Also, the volume regex is anchored `^[ \t]*Volume:` so `Base Volume:` (always 65536) can't be mistaken for the current level.

Volume is deliberately kept **out of** the provider's `meta`: `DeviceProviderRegistry.pollOnce` JSON-diffs that object to decide when to emit `deviceList`, and a fluctuating volume there would spam the manager every poll.

## Scope calls worth reviewing

- **Sources are untouched.** Input gain on a capture device is often a genuine analogue trim rather than a stale restore. One-line change if we want it.
- **Mute is untouched.** A muted hardware sink still silences everything and software volume can't rescue it, but muting reads as intentional in a way that 40% doesn't.
- **Trade-off:** device volume is no longer adjustable outside Media Router — an operator turning a sink down with `pactl` will see it snap back within one poll. That's the intent (one authoritative gain stage), but it is a behaviour change.

## Docs

- **ADR-0006** locks the gain-staging policy — "hardware sinks stay at unity" is exactly the kind of thing a future reader would helpfully "fix" out.
- Numbered **0006, not 0005**: `feat/rate-telemetry` already holds 0005 unmerged, so this avoids a collision when both land.
- Behaviour noted in `plugins/README.md` under `registerServices`.

## Tests

`pnpm test` → **1985 passing across 145 files**, 9 skipped. 40 in the three touched files: 9 new normalizer tests, 6 new parser tests (including the verbatim 40% `pactl` block as a fixture), 3 new provider tests.

Not deployed anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)