### PR TITLE
Video player: 50 fps paced playout, CPU halved, renderWatch — field-verified

### DIFF
--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -20,9 +20,12 @@ routing and the LCP display, which is why weston is there).
       source-vs-display clock drift beat, ±1 vblank, imperceptible). Runner
       cost 0.26 core — tsparse on the BATCHED bus costs ~0.02 core (vs 0.11
       unbatched: its price was per-buffer overhead), so pacing is nearly
-      free and the batching + pacing changes compose. Remaining decision:
-      whether `sync` should default ON for playout deployments (latency
-      budget permitting). Original item, for context: With `sync=false`
+      free and the batching + pacing changes compose. DECIDED 2026-08-01:
+      `sync` defaults ON (knob kept as the ultra-low-latency / degraded-PCR
+      escape hatch — see the DEPLOY NOTE in TodoNotes.md). Latency measured:
+      frames arrive at median ~0-1 ms before their presentation deadline, so
+      pacing adds ~nothing at the median and up to a few tens of ms of
+      per-frame jitter smoothing. Original item, for context: With `sync=false`
       nothing paces frames — arrival jitter reaches the compositor and
       latest-wins latching turns it into ~12 skipped vblanks/s (measured;
       independent of bus batching at 0/10/20 ms). The designed fix is live on

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -262,6 +262,17 @@ box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
         runner for the next occurrence (revert = redeploy engine dist).
       * TODO: surface librist quality/missing/recovered in the rist-input
         module's health/status so recovered-loss storms are operator-visible.
+        → DONE 2026-08-02 (Loss % field + hysteresis health warning).
+      * Related incident (2026-08-02 09:10): an 832 ms WAN blackout made
+        librist delete+recreate the flow; the runner's rist-reader thread
+        exited on the transient read error (-3) and never drained the new
+        flow's fifo ("Rist data out fifo queue overflow") — relay wedged
+        until a module restart, downstream ts-splitter "no input data".
+        Fixed: read loop now retries through RistError instead of breaking.
+        The video player resumed from its watchdog fallback with corrupted
+        decoder state (green band + ~10 late-drops/window) that persisted
+        until an engine restart — resume-from-stall could force a decoder
+        drain/reset; not yet addressed.
       * CAUTION (measurement hazard): per-buffer Python pad probes on
         packet-sized buffers (~750/s × 2 pads) overloaded the relay on a
         Pi 4 under storm load (relay 0.07 → 1.6 cores, presented collapsed

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -106,6 +106,15 @@ validation gate below before concluding any of it.**
       memfd+send. Needs a gstreamer1.0-plugins-bad rebuild — ride along with
       the SAND image build. Expected: most of the relay's non-librist cost
       (~0.16 core) plus mr-tssplit receive overhead.
+- [ ] **RT scheduling for audio/streaming threads (image).** PipeWire's
+      processing threads and librist's data-output thread run without RT
+      priority on the yocto image (librist logs "Failed to set data output
+      thread to RR scheduler"; no rtkit / RLIMIT_RTPRIO for the mrstation
+      user). On a 50-60 %-loaded Pi 4 that scheduling jitter is why the
+      paced audio sink needs ~170 ms of pacing margin to avoid xruns
+      (field 2026-08-02: 100 ms ring + 250 ms offset still xruns ~1/3 min).
+      An RLIMIT_RTPRIO/rtkit fix shrinks jitter for every audio consumer at
+      once and would let syncOffsetMs come back down.
 - [ ] **librist `rist-reader` thread: 0.27 core.** Library-internal cost of
       RIST receive; investigate librist config (profile, reorder buffer,
       crypto) before considering upstream work. Lowest priority of the CPU
@@ -271,8 +280,15 @@ box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
         Fixed: read loop now retries through RistError instead of breaking.
         The video player resumed from its watchdog fallback with corrupted
         decoder state (green band + ~10 late-drops/window) that persisted
-        until an engine restart — resume-from-stall could force a decoder
-        drain/reset; not yet addressed.
+        until an engine restart. ADDRESSED (2026-08-02, three parts):
+        resume now waits for 3 consecutive flowing polls before rebuilding
+        live (no rebuild against a churning source); render_lag treats
+        sustained sink drops (>5 % of expected) as lag even when presented
+        fps sits inside the hysteresis band (the degraded state was 0.88 —
+        silent for 5 min); and a renderwatch lag within 120 s of a
+        stall-resume triggers ONE automatic rebuild. Field repro of the
+        original corruption is still outstanding (needs an upstream stall
+        >5 s — SIGSTOP repro was not possible in-session).
       * CAUTION (measurement hazard): per-buffer Python pad probes on
         packet-sized buffers (~750/s × 2 pads) overloaded the relay on a
         Pi 4 under storm load (relay 0.07 → 1.6 cores, presented collapsed

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -14,16 +14,20 @@ routing and the LCP display, which is why weston is there).
 
 ## Performance — frame rate (the 37 → 50 fps gap)
 
-- [ ] **waylandsink commit pacing (gst-level) — the main fps lever.** The sink
-      commits only on frame callbacks; weston dispatches callbacks at repaint
-      start, so any callback→commit slip past the cycle boundary drops a whole
-      vblank (measured: commits cluster at vblank+5.6 ms; repaint loop idles
-      40–120 ms in `exit_loop` during misses; sink discards the excess —
-      `rendered`/`dropped` ≈ 37/13 fps). Ruled out: runner priority,
-      repaint-window in both directions (5 worse / 15 best / 18 equal),
-      overdraw, GPU clocks. Fix directions: commit a staged buffer without
-      waiting for the callback when one is due, or pace commits to the
-      presentation clock.
+- [ ] **waylandsink commit pacing — PATCH WRITTEN, awaiting build + field
+      verify.** `0007-waylandsink-commit-staged-buffers-without-waiting-fo.patch`
+      in media-router-yocto's gst-plugins-bad bbappend (applies after the SAND
+      series): staged buffers get an immediate display-thread commit instead
+      of parking behind the compositor's frame callback — the measured cause
+      of the 35 fps ceiling (commits clustered at vblank+5.6 ms, repaint loop
+      idling 40–120 ms in `exit_loop`, sink discarding the excess; ruled out:
+      runner priority, repaint-window both ways, overdraw, GPU clocks). Also
+      fixes a latent teardown use-after-free (frame callback pointer
+      overwritten while armed). Rides the SAND image build together with the
+      unixfdsink ingest coalescing below; verify with renderWatch — expect
+      presented ≈ repaint rate (~50) and sink drops ≈ 0, and re-check the
+      `repaint-window=15` choice afterwards (with per-buffer commits the
+      15 ms window may no longer matter for the video path).
 - [ ] **weston patch (alternative/complement, upstreamable):** dispatch frame
       callbacks at flip-completion instead of repaint start — widens every
       client's turnaround budget to a full cycle and removes ~20 ms latency

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -14,7 +14,15 @@ routing and the LCP display, which is why weston is there).
 
 ## Performance — frame rate — SOLVED at the sink; smooth-mode designed
 
-- [ ] **Validate smooth mode (the residual ~2/s judder).** With `sync=false`
+- [x] **Smooth mode VALIDATED (2026-08-01).** With "Honour buffer PTS" on:
+      operator confirms smooth playback; weston timeline shows a flat 50
+      flips/s with skipped vblanks 12.2/s → 2.2/s (the floor is the
+      source-vs-display clock drift beat, ±1 vblank, imperceptible). Runner
+      cost 0.26 core — tsparse on the BATCHED bus costs ~0.02 core (vs 0.11
+      unbatched: its price was per-buffer overhead), so pacing is nearly
+      free and the batching + pacing changes compose. Remaining decision:
+      whether `sync` should default ON for playout deployments (latency
+      budget permitting). Original item, for context: With `sync=false`
       nothing paces frames — arrival jitter reaches the compositor and
       latest-wins latching turns it into ~12 skipped vblanks/s (measured;
       independent of bus batching at 0/10/20 ms). The designed fix is live on

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -12,10 +12,18 @@ video-player runner CPU is **0.24 core** (decode+display dominate). Direction
 decided: stay on weston — kmssink is last-resort only (it complicates output
 routing and the LCP display, which is why weston is there).
 
-## Performance — frame rate (the 37 → 50 fps gap)
+## Performance — frame rate (the 37 → 50 fps gap) — SOLVED, awaiting image build
 
-- [ ] **waylandsink commit pacing — PATCH WRITTEN, awaiting build + field
-      verify.** `0007-waylandsink-commit-staged-buffers-without-waiting-fo.patch`
+- [x] **waylandsink commit pacing — FIELD-VERIFIED at 50 fps.** Live 1080p50:
+      arrivals == presented == ~50 fps, dropped == 0, RSS flat over a soak
+      (was ~35/15). Patch v3 is deadlock-hardened: v1 hit an AB-BA between
+      `window_lock` and the display thread's `sync_mutex` (held across
+      callback dispatch) — syncs are now created strictly outside
+      `window_lock` with a `commit_scheduled` flag closing the early-fire
+      race. Hand-built on the Pi 5 dev box against 1.28.2 and deployed on the
+      field device (`/data/gst-backup` holds stock; any OTA also reverts).
+      REMAINING: ships permanently via the image build (patch 0007 in the
+      gst-plugins-bad bbappend). Original item, for context: `0007-waylandsink-commit-staged-buffers-without-waiting-fo.patch`
       in media-router-yocto's gst-plugins-bad bbappend (applies after the SAND
       series): staged buffers get an immediate display-thread commit instead
       of parking behind the compositor's frame callback — the measured cause

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -236,6 +236,36 @@ box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
 - [ ] renderWatch expected-fps fallback: streams without VUI timing negotiate
       `framerate=0/1` and the watch stays silent; fall back to the ts-probe
       (`videoinfo`) framerate.
+- [x] renderWatch source-shortfall attribution (2026-08-01/02): the
+      intermittent "can only do 41 fps" warning on the OCC H.264 feed was NOT
+      render lag — per-window counters showed arrivals == presented,
+      dropped == 0: the sink presents everything that arrives. Runner now
+      reports `arrivalsFps` in renderwatch events; when achieved ≈ arrivals
+      the module warns "Stream under-delivering — check the source/link"
+      instead of the (wrong for this case) lower-the-resolution advice.
+- [ ] OCC feed delivery dips — root cause still open (2026-08-02 field
+      forensics, ~9 h of 4-point instrumentation on .108: wire/librist →
+      relay → tssplit → sink):
+      * The RIST WAN link runs recovered-loss storms in production hours
+        (10–20 % missing, RTT ~210 ms, librist recovers ~100 %, `lost=0`) —
+        which is exactly why ad-hoc link checks always came back "innocent":
+        only UNRECOVERED loss is visible without stats. A 130 missing/s storm
+        was absorbed cleanly (presented 97–101) by the 5 s buffer, so
+        moderate storms alone don't explain the warnings; worse storms might.
+      * Overnight there are shallow dips (presented 85–92 %, below warning
+        threshold) on a wall-clock grid (~:10/:40 s, gaps of exactly
+        60/300/600/1500 s) with NO wire dip, no discontinuities, no catch-up
+        burst, fanout `drops={}`. Origin unidentified (not cron, not engine
+        event-loop stalls — both phase-checked). A genuine warning episode
+        has not yet been caught with full instrumentation; RWX (sink windows)
+        + RSX (librist stats) diagnostics left ACTIVE on .108's deployed
+        runner for the next occurrence (revert = redeploy engine dist).
+      * TODO: surface librist quality/missing/recovered in the rist-input
+        module's health/status so recovered-loss storms are operator-visible.
+      * CAUTION (measurement hazard): per-buffer Python pad probes on
+        packet-sized buffers (~750/s × 2 pads) overloaded the relay on a
+        Pi 4 under storm load (relay 0.07 → 1.6 cores, presented collapsed
+        to 30–80) — probe per-frame or per-batch points only.
 - [ ] Fallback-card sizing under the source-sized live path (the accepted risk
       in `buildLivePipeline`): fallback should inherit the last live surface
       so kiosk-shell's same-size rule can't reject a live↔fallback

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -126,8 +126,35 @@ box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
        is DRM-only; a capsfilter alone still fails on the mandatory
        VideoMeta in decide_allocation. Use `… ! v4l2slh265dec !
        fakevideosink sync=false` (advertises all metas + any caps-features).
-2. [~] Live HEVC through the video player: pending an HEVC source on the
-       bus (current feed is H.264); file playback through waylandsink works.
+2. [ ] **Live HEVC through the player: FAILS — two distinct blockers found
+       when the OCC feed switched to H.265 (2026-08-01 evening):**
+       a. **1080p SAND hardware decode hangs** — the decisive bisect:
+          synthetic 720p50 decodes perfectly (1.0 s wall, 0.73 core-s);
+          synthetic 1080p50 AND a captured 10 s OCC sample
+          (`/data/test-media/occ-hevc-sample.ts`, Main@L4.1 1080p50
+          B-frames) hang the device with `Decoding frame 2 took too long
+          [v4l2slh265dec]`. Resolution-dependent, content-independent —
+          suspects are the resolution-scaled math in 0003 (absolute bit
+          size) / 0004 (slice-header offset) or SAND stride/column count at
+          1920 (15 cols vs 10). Repro assets on the device:
+          `hevc-720p50.ts` (passes) vs `hevc-1080p50.ts` (hangs) — for
+          oswald.
+       b. **decodebin3 never plugs the SAND decoder** (hangs inside
+          `db_output_stream_setup_decoder` with parsebin-fixated
+          `stream-format=hvc1` caps; direct `h265parse ! v4l2slh265dec`
+          works) — confirmed uncontended with file input, sink-independent.
+          Needs either a decodebin3-level fix or a codec-aware pipeline
+          builder in the video player (probe codec via tsProbe, build the
+          explicit parse+decoder chain, restart on codec change — decodebin3
+          reuse was for same-codec ABR switches, which the bus path doesn't
+          have).
+       INTERIM on the field device: the deployed video-player dist is
+       HAND-PATCHED to the direct HEVC chain (`decodebin3` →
+       `h265parse ! v4l2slh265dec` in dist/helpers/pipelines.js) — HEVC-only
+       and moot until (a) is fixed; the player shows the SMPTE fallback on
+       the current HEVC feed. **Recommend switching the OCC feed back to
+       H.264 for production until the 1080p SAND hang is fixed** (H.264 path
+       is fully validated at 50 fps smooth).
 3. [x] **SAND keeps the overlay plane**: weston places the NC12/SAND128
        dmabuf on overlay plane 125 (`FORMAT: NV12` in the atomic commits;
        no GL fallback, which could not have sampled SAND). Visual

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -12,7 +12,22 @@ video-player runner CPU is **0.24 core** (decode+display dominate). Direction
 decided: stay on weston — kmssink is last-resort only (it complicates output
 routing and the LCP display, which is why weston is there).
 
-## Performance — frame rate (the 37 → 50 fps gap) — SOLVED, awaiting image build
+## Performance — frame rate — SOLVED at the sink; smooth-mode designed
+
+- [ ] **Validate smooth mode (the residual ~2/s judder).** With `sync=false`
+      nothing paces frames — arrival jitter reaches the compositor and
+      latest-wins latching turns it into ~12 skipped vblanks/s (measured;
+      independent of bus batching at 0/10/20 ms). The designed fix is live on
+      the field device: enabling the module's existing **"Honour buffer PTS"
+      (`sync`) toggle** now rebuilds the chain with
+      `tsparse set-timestamps=true` (clock-anchored per-frame timestamps —
+      the long-shipped HLS pacing recipe) and the sink presents each frame on
+      time. Traced: unixfdsrc converts bus wire timestamps to running time,
+      tsparse re-anchors per-frame from PCR. Costs the 0.11-core tsparse only
+      while enabled; adds up to `bufferMs` of pacing latency. TO VALIDATE:
+      flip the toggle in the manager UI, eyeball smoothness, capture a weston
+      timeline histogram (expect skipped vblanks ≈ 0); consider making it the
+      recommended default for playout if latency permits.
 
 - [x] **waylandsink commit pacing — FIELD-VERIFIED at 50 fps.** Live 1080p50:
       arrivals == presented == ~50 fps, dropped == 0, RSS flat over a soak

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -146,6 +146,20 @@ routing and the LCP display, which is why weston is there).
 
 ## Smaller app follow-ups
 
+- [ ] **`clockSync` freezes on the first frame — epoch mismatch (diagnosed
+      2026-08-01).** With clockSync the chain deliberately passes source PES
+      timestamps through (`tsparse set-timestamps=false`) to share the A/V
+      timeline — but nothing maps the source epoch onto the shared clock's
+      running time, so the sink schedules the first frame at the raw PES
+      epoch (measured: 19.2 HOURS in the future) and waits. Structural, not
+      a regression: the pre-branch chain had the same shape. Needs the
+      engine's epoch/timeline-latch machinery (see `preserveSourceTimeline`
+      / the epoch-consistent latch work) wired into the video player's live
+      description, and clarity on whether the feature assumes a paired
+      audio-decoder pipeline that establishes the shared epoch. Until then:
+      leave the toggle OFF; with `sync` now defaulting ON, plain paced
+      playback covers everything except cross-pipeline lipsync.
+
 - [ ] renderWatch expected-fps fallback: streams without VUI timing negotiate
       `framerate=0/1` and the watch stays silent; fall back to the ts-probe
       (`videoinfo`) framerate.

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -6,15 +6,39 @@ field test and the 2026-08-01 instrumented sessions on the field Pi 4
 of `media-router-yocto` branch `feat/video-player-dynamic-surface` (the former
 `docs/video-player-display-handover.md`).
 
-**Where we are:** 1080p50 H.264 plays hardware-decoded, zero-copy on a vc4
-overlay plane (no GL in the video path), at **~37 fps presented / 50 decoded**;
-video-player runner CPU is **0.24 core** (decode+display dominate). Direction
-decided: stay on weston — kmssink is last-resort only (it complicates output
-routing and the LCP display, which is why weston is there).
+**Where we are (2026-08-01, end of session):** 1080p50 H.264 plays
+hardware-decoded, zero-copy on a vc4 overlay plane, **smooth at a flat
+50 fps** (paced presentation, now the default), runner CPU **0.26 core**.
+Direction decided: stay on weston — kmssink is last-resort only (it
+complicates output routing and the LCP display, which is why weston is there).
+**Every fix was validated on ONE Pi 4 field device — see the cross-machine
+validation gate below before concluding any of it.**
 
 ## Performance — frame rate — SOLVED at the sink; smooth-mode designed
 
-- [x] **Smooth mode VALIDATED (2026-08-01).** With "Honour buffer PTS" on:
+- [ ] **GATE: Pi 5 + Intel validation before concluding the display fixes.**
+      Everything below was verified on a single Pi 4 (vc4, hw H.264 decode),
+      but ALL of it ships fleet-wide: the waylandsink 0007 patch via the
+      shared gst-plugins-bad bbappend (all machine images), and the app-side
+      changes (sync default ON, tsparse-conditional chain, batching, F13/F19
+      fixes) via rootfs OTA. Machine-specific risks to test explicitly:
+      1. **waylandsink 0007 on other display stacks** — Pi 5 (rp1 DSI +
+         vc4-class HDMI) and Intel (i915) have different buffer-release and
+         flip timing than the path the deadlock analysis was done on; soak
+         each (the v1 deadlock took <1 s to appear on dmabuf, so a short
+         soak is meaningful, but include an SHM/software-decode source).
+      2. **`sync=true` default with SOFTWARE decode** — Pi 5 has no H.264
+         hw decode; paced presentation with 30-80 ms software decode times
+         against PTS deadlines is the exact `max-lateness` scenario the
+         buildSink notes warn about, and it was previously default-OFF
+         there. Watch renderWatch and visual cadence; if it misbehaves the
+         per-machine answer may be different defaults.
+      3. Batching (busBatchMs 20) + tsparse-conditional chain on each
+         machine's relay/consumer topology.
+      Until this gate passes, the fixes are "validated on Pi 4", not
+      "concluded".
+
+- [x] **Smooth mode VALIDATED on Pi 4 (2026-08-01).** With "Honour buffer PTS" on:
       operator confirms smooth playback; weston timeline shows a flat 50
       flips/s with skipped vblanks 12.2/s → 2.2/s (the floor is the
       source-vs-display clock drift beat, ±1 vblank, imperceptible). Runner
@@ -167,6 +191,8 @@ routing and the LCP display, which is why weston is there).
       in `buildLivePipeline`): fallback should inherit the last live surface
       so kiosk-shell's same-size rule can't reject a live↔fallback
       transition across a resolution change. Add a test for that transition.
-- [ ] Pi 5 / Intel app-behaviour smoke test before the next release: the app
-      ships to all machines via rootfs OTA regardless of the Pi 4-scoped
-      platform work (headless guard, compositor gate, surface path).
+- [ ] Pi 5 / Intel app-behaviour smoke test before the next release —
+      SUPERSEDED in scope by the cross-machine validation GATE at the top of
+      this file (which now also covers the display fixes); the original
+      smoke-test list (headless guard, compositor gate, surface path) still
+      applies as part of that gate.

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -1,129 +1,120 @@
-# TODO — Video player hardware decode & display pipeline (v2.0)
+# TODO — Video player: display path, performance & hardware decode (v2.0)
 
-Companion to `TodoNotes.md`; findings and follow-ups from the
-`feat/video-player-dynamic-surface` field test (2026-07-24/25, two Pi 400
-test devices, one live-relay + player, one player-only).
+Companion to `TodoNotes.md`. Open items only, distilled from the 2026-07-24/25
+field test and the 2026-08-01 instrumented sessions on the field Pi 4
+(`ivan-test.mediarouter.org`). Full investigation history lives in the git log
+of `media-router-yocto` branch `feat/video-player-dynamic-surface` (the former
+`docs/video-player-display-handover.md`).
 
-**Status: the branch is NOT PR-ready.** The code is complete and
-unit-tested (1955 TS tests + 19 python self-checks), and every behaviour was
-exercised on real hardware — but the platform underneath it has defects
-(below) that an OS/image update must fix first, and the branch must be
-re-tested on that updated OS before the PR.
+**Where we are:** 1080p50 H.264 plays hardware-decoded, zero-copy on a vc4
+overlay plane (no GL in the video path), at **~37 fps presented / 50 decoded**;
+video-player runner CPU is **0.24 core** (decode+display dominate). Direction
+decided: stay on weston — kmssink is last-resort only (it complicates output
+routing and the LCP display, which is why weston is there).
 
----
+## Performance — frame rate (the 37 → 50 fps gap)
 
-## What the branch changes (recap)
+- [ ] **waylandsink commit pacing (gst-level) — the main fps lever.** The sink
+      commits only on frame callbacks; weston dispatches callbacks at repaint
+      start, so any callback→commit slip past the cycle boundary drops a whole
+      vblank (measured: commits cluster at vblank+5.6 ms; repaint loop idles
+      40–120 ms in `exit_loop` during misses; sink discards the excess —
+      `rendered`/`dropped` ≈ 37/13 fps). Ruled out: runner priority,
+      repaint-window in both directions (5 worse / 15 best / 18 equal),
+      overdraw, GPU clocks. Fix directions: commit a staged buffer without
+      waiting for the callback when one is due, or pace commits to the
+      presentation clock.
+- [ ] **weston patch (alternative/complement, upstreamable):** dispatch frame
+      callbacks at flip-completion instead of repaint start — widens every
+      client's turnaround budget to a full cycle and removes ~20 ms latency
+      (cog included).
+- [ ] **Productize `[core] repaint-window=15`** — validated on the field
+      device (GL clients 25→50 fps; hand-set in `/data/weston.ini` there
+      ONLY). Belongs in `device-startup.sh`'s weston.ini creation/migration
+      (media-router-yocto).
 
-- **Surface follows the display's preferred mode** instead of hard-coded
-  1280×720 (`resolveConnectorMode`/`firstConnectedDisplay`). Measured on
-  hw-decoded 1080p50: fixed-720p forced an active software scale — 25 fps
-  ceiling at 2.6× decode CPU; matched surface puts videoconvert/videoscale
-  into caps passthrough — 57–60 fps at ~zero cost. (The ISP `v4l2convert`
-  was tried and reverted: hard ~46 fps ceiling at 1080p regardless of
-  output size — it can never sit in a 1080p50 path.)
-- **Headless guard** — DRM present but no connected physical output → no
-  pipeline + health `error` instead of a sink error-loop; recovers on
-  hotplug via the wayland-session watcher.
-- **Compositor gate** — hosts with waylandsink installed never fall back to
-  kmssink (it steals DRM master and fights the compositor's startup;
-  observed after display hotplug as video flashing over the console then
-  vanishing). Waiting state has its own health message.
-- **renderWatch** — runner-side keep-up monitor (`render_lag.py`): sink-pad
-  frame rate vs caps-declared framerate, hysteresis 0.85/0.95 ×3 windows,
-  post-start zero-frame windows count as lag (starvation is lag, not
-  stall). Surfaces in the manager UI as
-  *"Video output can't keep up (a/b fps) — lower the stream or display
-  resolution"*. Validated end-to-end on a starving software-HEVC pipeline.
+## Performance — CPU (runner now 0.24 core; remaining targets)
 
-## Platform findings (what the OS/image must fix)
+- [ ] **unixfdsink ingest coalescing (relay → mr-tssplit edge).** The relay
+      still pushes ~692 unbatched buffers/s (per-RTP ~1.3 KB) into
+      mr-tssplit's ingest; symmetric fix to `ae748f68` (mr-tssplit fanout
+      coalescing, 692→39 buf/s), implemented inside the
+      `0001-unixfdsink-never-block-slow-consumer-kick.patch` the yocto layer
+      already carries: accumulate to `BUFFER_BYTES` (24 KB) or 20 ms before
+      memfd+send. Needs a gstreamer1.0-plugins-bad rebuild — ride along with
+      the SAND image build. Expected: most of the relay's non-librist cost
+      (~0.16 core) plus mr-tssplit receive overhead.
+- [ ] **librist `rist-reader` thread: 0.27 core.** Library-internal cost of
+      RIST receive; investigate librist config (profile, reorder buffer,
+      crypto) before considering upstream work. Lowest priority of the CPU
+      items.
 
-### 1. Boot partition incoherence → HEVC decoder silently absent
+## Hardware HEVC (blocked on the SAND image build)
 
-- Kernel 6.12 renamed the HEVC decoder's DT compatible
-  (`raspberrypi,rpivid-vid-decoder` → `raspberrypi,hevc-dec`). Devices
-  whose boot partition carries kernel 6.12 (May 2026 build) with DTBs from
-  the 2024-12-20 bootfiles set have a node the driver never matches:
-  `/dev/video19` never appears, **zero errors anywhere**.
-- The OTA updater covers rootfs slots only — boot partitions drift by
-  provisioning date. Three same-app-version devices had three different
-  boot states (one with working `rpi-hevc-dec`, two without).
-- Temporary fix applied to one test device (backups in
-  `/data/bootfw-backup-20241220/`): firmware release **1.20260521**
-  `start4.elf` + `fixup4.dat` + `bcm2711-rpi-400.dtb` + used overlays
-  (`vc4-kms-v3d.dtbo`, `gpio-fan.dtbo`). After reboot the node matches and
-  `/dev/video19` auto-registers.
-- **Build requirement:** ship kernel + DTBs + overlays from the same kernel
-  build, with a matched firmware pair; include the boot partition in the
-  update/versioning story (or stamp + audit it).
+- [ ] **Build & flash oswald's `feat/video-palyer-add-hevc-support` yocto
+      branch** (SAND patches for gst-plugins-bad/-base). Gate list on a
+      device, in order:
+      1. decode proof: `/data/test-media/hevc-720p50.ts` (on the field
+         device; regenerate with ffmpeg/libx265, 4 s testsrc2 720p50 TS) must
+         reach EOS via `v4l2slh265dec` with user CPU ≪ clip length — on stock
+         libs it fails `not-negotiated` in 0.22 s;
+      2. live HEVC through the video player;
+      3. **do SAND/NC12 dmabufs keep the overlay-plane path?** vc4 planes
+         support SAND natively, but weston must accept the Broadcom SAND
+         modifier for plane placement — else HEVC decodes but falls to a GL
+         path that cannot sample SAND;
+      4. re-probe GPU DVFS (`meta-custom/scripts/vcprobe.py`) — see platform
+         items below.
+- [ ] **Until then: H.264-only routing to Pi 4 players** (policy, not code).
+      Software HEVC is NOT a fallback: measured 6.7 core-s for a 4 s 720p50
+      clip — not realtime even at 720p.
+- [ ] **Ship the `v4l2slh265dec` rank mask**
+      (`GST_PLUGIN_FEATURE_RANK=v4l2slh265dec:0` in the engine unit env) until
+      the SAND gate passes: the decoder registers at rank 257 and decodebin3
+      has no fallback, so any HEVC stream error-loops today. The field device
+      has NO mask installed. Remove once SAND is proven.
+- [ ] Pi 5 characterization before making rank/routing per-machine: Pi 5 is
+      the inverse of Pi 4 (H.265 hw only, no H.264 hw — FDS §2065).
 
-### 2. GStreamer cannot use the HEVC block (even when present)
+## Platform / image (media-router-yocto)
 
-- The `rpivid` engine outputs **column-tiled (SAND / NC12,
-  `NV12MT_COL128`) frames**. GStreamer 1.28.2's `v4l2slh265dec` fails:
-  system-memory path → `Unsupported pixel format`; DMABuf path to
-  waylandsink → `Failed to configure the buffer pool` (format negotiates,
-  pool config doesn't — consistent with partially-landed support).
-- Upstream state: v4l2codecs SAND support MR exists and passes 142/147 of
-  the JCT-VC HEVC conformance suite; `NV12MT_COL128` is in v4l2-core; the
-  driver itself is upstreamed.
-  - https://discourse.gstreamer.org/t/v4l2codecs-feasibility-of-adding-support-for-raspberry-pi-hevc-sand-formats-nc12-nc30/3522
-  - https://lwn.net/Articles/1060711/
-- **Build requirement:** a GStreamer new enough to include the completed
-  v4l2codecs SAND work (or cherry-pick the MR / carry vendor patches).
-  Gate it with a **real decode proof in image CI**: a test HEVC TS must
-  reach EOS with user-CPU ≪ clip duration. Device presence proves nothing —
-  every failure in this saga was silent at the "file exists" level.
+- [ ] **Boot-partition coherence (the original F1).** Kernel/DTB/firmware must
+      ship as a matched set and be stamped+audited; OTA covers rootfs only, so
+      boot partitions drift silently by provisioning date. The
+      `rpi-bootfiles.bbappend` 20241220 pin predates the 6.12 kernel; unpin
+      globally and regression-check the two DSI devices (Pi 4 + Touch Display,
+      Pi 5 + Touch Display 2).
+- [ ] **GPU DVFS broken on the field device**: v3d/h264/isp/hevc pinned at
+      their 250 MHz idle floor under full load (likely a firmware/DTB
+      mismatch symptom). `force_turbo=1` is the interim on `.108`. Re-probe
+      after the boot-coherence fix; `vcprobe.py` is the tool (the image ships
+      neither vcgencmd nor debugfs — consider adding vcgencmd to the image).
+- [ ] **Bake the validated display config into the image**: `cma-128` on the
+      vc4 overlay + `gpu_mem_1024=76` (both field-validated — the 512 MiB CMA
+      default silently falls back to 6 MiB and crash-loops weston;
+      `gpu_mem_1024=396` steals ~320 MB unused under KMS). Pi 4 conf has
+      `disable_fw_kms_setup=1` already; mirror CMA decisions on Pi 5 after
+      measuring there.
+- [ ] **CI decode-proof gate** in the image build: a generated HEVC/H.264 TS
+      must decode to EOS with bounded CPU — device-node presence proves
+      nothing (every failure in this saga was silent at the file-exists
+      level).
+- [ ] **Observability debt on kiosk hosts**: engine stdout doesn't reach
+      journald (unowned bug — a `/tmp/engine.log` drop-in is the field
+      workaround); mask getty on the compositor VT (keypress steals the
+      display); image lacks vcgencmd/debugfs.
+- [ ] RAUC rootfs slot margin: re-check the 4 GiB fit when the SAND gstreamer
+      lands (`IMAGE_OVERHEAD_FACTOR` is pinned tight).
 
-### 3. decodebin3 has no decoder fallback → mask required until (2) lands
+## Smaller app follow-ups
 
-- With `v4l2slh265dec` registered (rank 257 > avdec's 256) and broken,
-  decodebin3 picks it and the pipeline **dies with no fallback** — HEVC
-  playback error-loops instead of degrading to software.
-- **Build requirement (interim):** `GST_PLUGIN_FEATURE_RANK=v4l2slh265dec:0`
-  in the engine service environment (a user-unit drop-in
-  `media-router.service.d/hevc-mask.conf` carries it on the test device).
-  Remove when (2) is proven.
-
-### 4. Software HEVC budget (measured, Pi 400 @ stock clocks)
-
-- Dense 8-bit 1080p50 broadcast HEVC via `avdec_h265` (4 threads):
-  **~32 fps max, ~2.5 core-seconds per second of stream** — cannot sustain
-  50 fps even unloaded; on a loaded box the leaky queues shed keyframes →
-  grey frames with motion smear.
-- H.264 1080p50 hardware decode (`v4l2h264dec`) works end-to-end today
-  (~62 fps, low CPU).
-- **Until (1)+(2) land: player endpoints must receive H.264, or HEVC at
-  ≤720p50.** This is a routing/feed decision, not code.
-
-### 5. Kiosk platform details (also in
-`hardware-setup-recommendations.md`)
-
-- `getty` and the compositor must not share a VT — a keypress (on
-  keyboard-integrated devices, any key) hands the display to the login
-  console and pauses the compositor (`atomic commit: Permission denied`
-  flood). Disable the console getty on kiosk hosts.
-- The compositor EACCES flood filled the 64 MB runtime journal and engine
-  logs went dark. **Unresolved residual:** engine stdout stopped reaching
-  journald and did not recover after journald restart + vacuum + engine
-  restarts — needs its own investigation (observability loss on exactly
-  the boxes that misbehave).
-- Empty EDID (bad cable/adapter) → VESA fallback 1024×768 4:3 → letterbox
-  that looks like an aspect bug. Verify EDID bytes at install time.
-
-## Branch follow-ups (before/at PR, after the OS update)
-
-- [ ] **Re-test the full branch on the updated OS** — the PR gate. Includes
-      re-running the sw-vs-hw scale benchmarks and the renderWatch
-      behaviour with a working hw HEVC decoder.
-- [ ] **Surface caps must admit DMABuf** once hw HEVC lands: zero-copy
-      SAND→compositor only works if nothing touches pixels — exactly the
-      surface==source passthrough case — but today's surface caps pin
-      system-memory `video/x-raw`, which would force a download. Extend
-      `surfaceCaps()` to offer `video/x-raw(memory:DMABuf)` alongside.
-- [ ] **renderWatch expected-fps fallback**: streams without VUI timing
-      negotiate `framerate=0/1` and the monitor stays silent by design.
-      Fall back to the framerate the ts-probe (`videoinfo`) reports.
-- [ ] Consider surfacing `cpuDecodeThreading=frame` as guidance when the
-      lag warning fires on a software-decode pipeline (frame-threading
-      trades latency for throughput).
-- [ ] Journald/engine-logging investigation (see 5).
+- [ ] renderWatch expected-fps fallback: streams without VUI timing negotiate
+      `framerate=0/1` and the watch stays silent; fall back to the ts-probe
+      (`videoinfo`) framerate.
+- [ ] Fallback-card sizing under the source-sized live path (the accepted risk
+      in `buildLivePipeline`): fallback should inherit the last live surface
+      so kiosk-shell's same-size rule can't reject a live↔fallback
+      transition across a resolution change. Add a test for that transition.
+- [ ] Pi 5 / Intel app-behaviour smoke test before the next release: the app
+      ships to all machines via rootfs OTA regardless of the Pi 4-scoped
+      platform work (headless guard, compositor gate, surface path).

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -111,22 +111,32 @@ validation gate below before concluding any of it.**
       crypto) before considering upstream work. Lowest priority of the CPU
       items.
 
-## Hardware HEVC (blocked on the SAND image build)
+## Hardware HEVC — WORKING via hand-deployed SAND stack (2026-08-01)
 
-- [ ] **Build & flash oswald's `feat/video-palyer-add-hevc-support` yocto
-      branch** (SAND patches for gst-plugins-bad/-base). Gate list on a
-      device, in order:
-      1. decode proof: `/data/test-media/hevc-720p50.ts` (on the field
-         device; regenerate with ffmpeg/libx265, 4 s testsrc2 720p50 TS) must
-         reach EOS via `v4l2slh265dec` with user CPU ≪ clip length — on stock
-         libs it fails `not-negotiated` in 0.22 s;
-      2. live HEVC through the video player;
-      3. **do SAND/NC12 dmabufs keep the overlay-plane path?** vc4 planes
-         support SAND natively, but weston must accept the Broadcom SAND
-         modifier for plane placement — else HEVC decodes but falls to a GL
-         path that cannot sample SAND;
-      4. re-probe GPU DVFS (`meta-custom/scripts/vcprobe.py`) — see platform
-         items below.
+The full SAND set (base 0001 + bad 0002–0007, incl. the pacing patch — all
+seven apply and build together cleanly) was built natively on the Pi 5 dev
+box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
+`/data/gst-backup`; libgstvideo swapped atomically). Gate results:
+1. [x] **Decode proof PASSES**: 4 s 720p50 HEVC → EOS in 1.0 s wall,
+       **0.73 core-seconds total** (software: 6.7) — hardware decode on the
+       hevc block, `Selected format NV12_128C8 DRM NV12:SAND128`.
+       **Test-recipe gotchas (bake into the CI gate):** a bare `fakesink`
+       CANNOT prove SAND decode — upstream v4l2codecs hides DRM formats
+       from ANY-caps peers (`static_src_caps_no_drm`), and post-0006 SAND
+       is DRM-only; a capsfilter alone still fails on the mandatory
+       VideoMeta in decide_allocation. Use `… ! v4l2slh265dec !
+       fakevideosink sync=false` (advertises all metas + any caps-features).
+2. [~] Live HEVC through the video player: pending an HEVC source on the
+       bus (current feed is H.264); file playback through waylandsink works.
+3. [x] **SAND keeps the overlay plane**: weston places the NC12/SAND128
+       dmabuf on overlay plane 125 (`FORMAT: NV12` in the atomic commits;
+       no GL fallback, which could not have sampled SAND). Visual
+       confirmation of no chroma corruption = the 0006 single-object fix
+       doing its job (operator eyeball still advised).
+4. [ ] DVFS re-probe after boot-coherence fix (unchanged; `force_turbo=1`
+       still masks it on the field device).
+- [ ] **Image build remains the delivery vehicle** — the hand-deploy proves
+      the exact artifact set oswald's branch + patch 0007 will produce.
 - [ ] **Until then: H.264-only routing to Pi 4 players** (policy, not code).
       Software HEVC is NOT a fallback: measured 6.7 core-s for a 4 s 720p50
       clip — not realtime even at 720p.

--- a/docs/TodoNotes-video-hw-decode.md
+++ b/docs/TodoNotes-video-hw-decode.md
@@ -128,7 +128,19 @@ box against 1.28.2 and hand-deployed on the field Pi 4 (stock in
        fakevideosink sync=false` (advertises all metas + any caps-features).
 2. [ ] **Live HEVC through the player: FAILS — two distinct blockers found
        when the OCC feed switched to H.265 (2026-08-01 evening):**
-       a. **1080p SAND hardware decode hangs** — the decisive bisect:
+       a. **1080p SAND hardware decode hangs — SEVERITY: CAN FREEZE THE
+          ENTIRE DEVICE.** After the player retried 1080p HEVC decode for a
+          while, the field box hard-hung: frozen last frame on screen,
+          network down, power-cycle required (operator-confirmed,
+          2026-08-01 evening). A wedged rpivid/V4L2 decode job apparently
+          takes the kernel with it — treat as critical, not just a decode
+          failure. Boot-time evidence is lost (no persistent journal on the
+          image — see observability debt). INTERIM GUARD on the field box:
+          `media-router.service.d/hevc-mask.conf` sets
+          `GST_PLUGIN_FEATURE_RANK=v4l2slh265dec:0` so the patched decoder
+          is never auto-selected (explicit test pipelines can still use it
+          for repro work); the hand-patched dist was restored to the built
+          decodebin3 chain. The decisive bisect:
           synthetic 720p50 decodes perfectly (1.0 s wall, 0.73 core-s);
           synthetic 1080p50 AND a captured 10 s OCC sample
           (`/data/test-media/occ-hevc-sample.ts`, Main@L4.1 1080p50

--- a/docs/TodoNotes.md
+++ b/docs/TodoNotes.md
@@ -2,6 +2,14 @@
 
 ## Open
 
+- [ ] **DEPLOY NOTE — video-player `sync` default flips ON (2026-08-01):**
+  instances whose stored config never set `sync` change from
+  present-on-arrival to clock-paced presentation on the next engine update
+  (smooth playback; ~zero median added latency, field-measured). Watch for
+  feeds with broken/discontinuous PCR — under pacing they can stall or drop
+  where they previously played jerkily; fix is flipping "Honour buffer PTS"
+  OFF on that instance. Explicitly-set configs keep their value.
+
 - [ ] **Injected plugins have no test home (2026-07-29, opened with ADR-0004):** `webrtc-client` moved to the `media-router-audio-app` repo under `media-router-plugin/`, taking its 138-line `WebRtcClientModule.test.ts` with it — but an injected plugin can't typecheck or run standalone there (its `tsconfig.json` extends `../tsconfig.plugin.json`, which only exists once the Yocto recipe copies it into this workspace), so those tests currently run **nowhere** and this repo's test baseline drops by that file's count. Fix direction: a harness in the owning repo that checks out media-router, injects `media-router-plugin/*`, and runs `pnpm test` — or, if that proves not worth it, move the tests back here as a plugin-contract test against the injected build. Until then, treat injected plugins as untested in CI.
 
 - [ ] **DEPLOY NOTE — transcoder single-input + strict 302M pins (2026-07-23, uncommitted):** on the first engine start after this lands, two classes of stored edges are dropped silently (visible only in engine logs): (a) edges into the audio-transcoder's removed `audio-in` mix port (its 302M mix moved to the new `audio-mixer` plugin — rewire through it), and (b) muxed-declared sources wired into now-strict 302M pins (`audio-mixer`/`audio-output-302m`/`n1-mixer-302m` inputs declare `acceptsStreamTypes: ["audio/302m"]`; previously legal via TS-family leniency, e.g. an SRT input carrying remote 302M — now needs an Audio Transcoder in front). Audit fleet profiles for both patterns before deploying. Follow-up worth building: when `ConnectionApplier` exhausts retries on a validation reject, surface a one-time health warning on the sink module so the operator sees why audio went dead instead of digging in logs.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -20,7 +20,7 @@
         }
     },
     "scripts": {
-        "build": "tsc && cp src/child-process/gst-pipeline-runner.py src/child-process/gst-net-clock.py dist/child-process/",
+        "build": "tsc && cp src/child-process/gst-pipeline-runner.py src/child-process/gst-net-clock.py src/child-process/render_lag.py dist/child-process/",
         "typecheck": "tsc --noEmit",
         "dev": "bash -c '[ -f .env.local ] && . ./.env.local; exec tsx watch --inspect=9230 examples/test-engine.ts'"
     },

--- a/packages/engine/src/child-process/GstChildProcess.ts
+++ b/packages/engine/src/child-process/GstChildProcess.ts
@@ -196,6 +196,7 @@ export class GstChildProcess extends EventEmitter {
             busReports: desc.busReports ?? [],
             rist: desc.rist,
             tsProbe: desc.tsProbe,
+            renderWatch: desc.renderWatch,
             preserveSourceTimeline: desc.preserveSourceTimeline,
         };
     }

--- a/packages/engine/src/child-process/PythonProcess.ts
+++ b/packages/engine/src/child-process/PythonProcess.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'child_process';
-import type { PadLinkRule, BusReport, RistRunnerConfig, TsProbeRunnerConfig, PreserveSourceTimelineConfig } from '../plugins/PluginModule.js';
+import type { PadLinkRule, BusReport, RistRunnerConfig, TsProbeRunnerConfig, RenderWatchRunnerConfig, PreserveSourceTimelineConfig } from '../plugins/PluginModule.js';
 import type { ClockConfig } from './ClockAuthority.js';
 import { pluginPythonPaths } from './nativeBinaries.js';
 
@@ -24,6 +24,7 @@ export interface RunnerStartOptions {
     busReports?: BusReport[];
     rist?: RistRunnerConfig;
     tsProbe?: TsProbeRunnerConfig;
+    renderWatch?: RenderWatchRunnerConfig;
     preserveSourceTimeline?: PreserveSourceTimelineConfig;
 }
 

--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -2490,11 +2490,17 @@ def _start_render_watch(pipe, cfg):
         ev = st["mon"].tick(achieved, RENDER_WATCH_WINDOW_MS / 1000.0, _expected_fps())
         if ev:
             kind, achieved_fps, expected = ev
+            # arrivalsFps lets the module tell RENDER lag (sink presents fewer
+            # frames than arrive) from SOURCE shortfall (fewer frames arrive
+            # in the first place — a feed/link problem the render chain can't
+            # fix and must not be blamed for).
             emit_plugin_event(f"renderwatch:{kind}",
                               {"achievedFps": round(achieved_fps, 1),
                                "expectedFps": round(expected, 2),
                                "droppedFps": round(
-                                   dropped / (RENDER_WATCH_WINDOW_MS / 1000.0), 1)})
+                                   dropped / (RENDER_WATCH_WINDOW_MS / 1000.0), 1),
+                               "arrivalsFps": round(
+                                   arrivals / (RENDER_WATCH_WINDOW_MS / 1000.0), 1)})
         return True                          # keep the GLib timer alive
 
     st["probe_id"] = pad.add_probe(Gst.PadProbeType.BUFFER, _on_buffer)

--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -2500,7 +2500,8 @@ def _start_render_watch(pipe, cfg):
                 if d_rendered >= 0 and d_dropped >= 0:
                     achieved = d_rendered
                     dropped = d_dropped
-        ev = st["mon"].tick(achieved, RENDER_WATCH_WINDOW_MS / 1000.0, _expected_fps())
+        ev = st["mon"].tick(achieved, RENDER_WATCH_WINDOW_MS / 1000.0, _expected_fps(),
+                            dropped / (RENDER_WATCH_WINDOW_MS / 1000.0))
         if ev:
             kind, achieved_fps, expected = ev
             # arrivalsFps lets the module tell RENDER lag (sink presents fewer

--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -2200,13 +2200,26 @@ def _start_rist(pipe, cfg):
                 # thread-safe. A push before PLAYING / during teardown returns
                 # FLUSHING and the buffer drops — live-source semantics,
                 # exactly what udpsrc did under the CLI relay.
+                #
+                # A read error is TRANSIENT: librist deletes and recreates the
+                # flow around a link blackout (field case 2026-08-02: peer dead
+                # 832 ms → flow deleted → read returned -3), then keeps
+                # receiving into its fifo. Exiting the loop here left that fifo
+                # undrained ("Rist data out fifo queue overflow") and wedged
+                # the relay until a module restart — so warn once per error
+                # burst and keep reading.
+                err_streak = 0
                 while not _rist_stop.is_set():
                     try:
                         data = ctx.read(100)
                     except librist.RistError as e:
-                        emit_event({"event": "warning",
-                                    "message": f"librist read failed: {e}"})
-                        break
+                        err_streak += 1
+                        if err_streak == 1:
+                            emit_event({"event": "warning",
+                                        "message": f"librist read failed (retrying): {e}"})
+                        _rist_stop.wait(0.1)
+                        continue
+                    err_streak = 0
                     if not data:
                         continue
                     try:

--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -1243,6 +1243,12 @@ def handle_start(data):
         pipeline = None
         return
 
+    # Report-only render keep-up watch (`renderWatch` config) — same window.
+    if not _start_render_watch(pipeline, data.get("renderWatch")):
+        pipeline.set_state(Gst.State.NULL)
+        pipeline = None
+        return
+
     # Set up bus watch
     bus = pipeline.get_bus()
     bus.add_signal_watch()
@@ -1276,6 +1282,7 @@ def handle_stop(data=None):
     _clear_preserve_timeline()
     _stop_rist()
     _stop_ts_probe()
+    _stop_render_watch()
     if pipeline:
         pipeline.set_state(Gst.State.NULL)
         running = False
@@ -2384,6 +2391,128 @@ def _stop_ts_probe():
     # State rides the appsink streaming thread; NULL transition stops it.
     global _ts_probe
     _ts_probe = None
+
+
+# ---------------------------------------------------------------------------
+# Render keep-up watch (`renderWatch` config)
+# ---------------------------------------------------------------------------
+_render_watch = None      # state dict while a renderWatch pad probe is armed
+
+RENDER_WATCH_WINDOW_MS = 2000
+
+
+def _start_render_watch(pipe, cfg):
+    """Report-only render keep-up watch (`renderWatch: {sink}` config).
+
+    Judges the rate of frames the sink actually PRESENTS — GstBaseSink's
+    `stats` property (`rendered`/`dropped` counters) — against the framerate
+    the pad's negotiated caps declare. Counting pad arrivals instead is a
+    proven blind spot: on the 2026-08-01 Pi 4 investigation the pad saw a
+    clean 50 fps while waylandsink discarded 18 fps internally (compositor
+    frame-callback pacing), so an arrival-based watch reported everything
+    fine during exactly the stutter it exists to catch.
+
+    A pad probe still counts arrivals, but only as a gate: a window with NO
+    arrivals is the stall watchdog's condition (dead source), not render
+    lag, so those windows are fed as zero and the monitor's stall/preroll
+    logic applies. Sinks without a `stats` property fall back to arrival
+    counting (better than nothing on autovideosink-style bins).
+
+    The hysteresis lives in render_lag.RenderLagMonitor; state transitions
+    emit `renderwatch:lag` / `renderwatch:recovered` plugin events with
+    `{achievedFps, expectedFps, droppedFps}` so the owning module can warn
+    the operator. Never touches routing; a missing sink the module
+    explicitly asked to watch is a hard error (matches tsProbe).
+    """
+    global _render_watch
+    if not cfg:
+        return True
+    try:
+        from render_lag import RenderLagMonitor
+    except Exception as e:  # noqa: BLE001
+        emit_event({"event": "error", "message": f"render_lag unavailable: {e}"})
+        return False
+    sink = pipe.get_by_name(cfg.get("sink", ""))
+    if sink is None:
+        emit_event({"event": "error",
+                    "message": f"renderWatch: sink not found: {cfg.get('sink')!r}"})
+        return False
+    pad = sink.get_static_pad("sink")
+    if pad is None:
+        emit_event({"event": "error",
+                    "message": f"renderWatch: no sink pad on: {cfg.get('sink')!r}"})
+        return False
+
+    st = {"pad": pad, "sink": sink, "frames": 0, "mon": RenderLagMonitor(),
+          "probe_id": None, "timer_id": None, "prev_stats": None}
+
+    def _on_buffer(_pad, _info):
+        st["frames"] += 1
+        return Gst.PadProbeReturn.OK
+
+    def _expected_fps():
+        # Re-read every tick: a mid-stream format switch renegotiates caps and
+        # the monitor resets its streaks on an expected-fps change.
+        caps = pad.get_current_caps()
+        if not caps or caps.get_size() == 0:
+            return None
+        ok, num, den = caps.get_structure(0).get_fraction("framerate")
+        if not ok or num <= 0 or den <= 0:
+            return None                      # no VUI timing → nothing to judge
+        return num / den
+
+    def _sink_stats():
+        # (rendered, dropped) totals from GstBaseSink, or None when the sink
+        # doesn't expose them (not a basesink, e.g. an autovideosink bin).
+        try:
+            s = st["sink"].get_property("stats")
+            return s.get_value("rendered"), s.get_value("dropped")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _tick():
+        arrivals = st["frames"]
+        st["frames"] = 0
+        achieved = arrivals
+        dropped = 0
+        stats = _sink_stats()
+        if stats is not None:
+            prev = st["prev_stats"]
+            st["prev_stats"] = stats
+            # First window has no delta yet; a negative delta means the sink
+            # restarted its counters — both fall back to arrivals.
+            if prev is not None and arrivals > 0:
+                d_rendered = stats[0] - prev[0]
+                d_dropped = stats[1] - prev[1]
+                if d_rendered >= 0 and d_dropped >= 0:
+                    achieved = d_rendered
+                    dropped = d_dropped
+        ev = st["mon"].tick(achieved, RENDER_WATCH_WINDOW_MS / 1000.0, _expected_fps())
+        if ev:
+            kind, achieved_fps, expected = ev
+            emit_plugin_event(f"renderwatch:{kind}",
+                              {"achievedFps": round(achieved_fps, 1),
+                               "expectedFps": round(expected, 2),
+                               "droppedFps": round(
+                                   dropped / (RENDER_WATCH_WINDOW_MS / 1000.0), 1)})
+        return True                          # keep the GLib timer alive
+
+    st["probe_id"] = pad.add_probe(Gst.PadProbeType.BUFFER, _on_buffer)
+    st["timer_id"] = GLib.timeout_add(RENDER_WATCH_WINDOW_MS, _tick)
+    _render_watch = st
+    return True
+
+
+def _stop_render_watch():
+    global _render_watch
+    st = _render_watch
+    _render_watch = None
+    if not st:
+        return
+    if st["timer_id"] is not None:
+        GLib.source_remove(st["timer_id"])
+    if st["probe_id"] is not None:
+        st["pad"].remove_probe(st["probe_id"])
 
 
 # Command dispatch

--- a/packages/engine/src/child-process/render_lag.py
+++ b/packages/engine/src/child-process/render_lag.py
@@ -1,0 +1,89 @@
+"""Render keep-up detector for a video sink (pure logic, no GStreamer).
+
+The runner counts buffers reaching the sink pad and, once per window, feeds
+this monitor the count plus the framerate the stream *declares* in its
+negotiated caps. The monitor decides — with hysteresis — whether the pipeline
+is failing to keep up (frames are being shed upstream by the leaky queues /
+QoS) and reports state TRANSITIONS only:
+
+    tick(...) -> None | ("lag", achieved_fps, expected_fps)
+                      | ("recovered", achieved_fps, expected_fps)
+
+Rules:
+- `expected_fps` unknown (<= 0, e.g. caps without VUI timing) → nothing to
+  judge against; both streaks reset, no events.
+- Zero-frame windows BEFORE the first rendered frame are startup, not lag —
+  the pipeline may still be prerolling and a genuinely dead source is the
+  stall watchdog's condition. They reset the streaks.
+- Zero-frame windows AFTER frames have flowed count as lag (achieved 0):
+  a starving sink behind a still-flowing source is the worst lag there is —
+  a decoder that can't keep up sheds so much upstream that whole windows
+  come up empty, and treating those as "stall" would mask exactly the
+  condition this monitor exists to report.
+- Lag latches after `trip_windows` consecutive windows below
+  `lag_ratio * expected`; recovery clears it after `trip_windows` consecutive
+  windows at or above `recover_ratio * expected`. The gap between the two
+  ratios is the hysteresis band that stops flapping around the threshold.
+- A change in `expected_fps` (mid-stream format switch) resets the streaks —
+  windows straddling a switch would judge the old rate against the new caps.
+"""
+
+
+class RenderLagMonitor:
+    def __init__(self, lag_ratio=0.85, recover_ratio=0.95, trip_windows=3):
+        self.lag_ratio = lag_ratio
+        self.recover_ratio = recover_ratio
+        self.trip_windows = trip_windows
+        self.lagging = False
+        self._below = 0
+        self._above = 0
+        self._last_expected = None
+        self._started = False   # True once any window has rendered frames
+
+    def reset(self):
+        self._below = 0
+        self._above = 0
+        self._last_expected = None
+        # `lagging` and `_started` survive reset() on purpose: a caps switch
+        # mid-lag should not synthesize a "recovered" event (recovery must be
+        # measured), and it doesn't un-happen that frames have flowed.
+
+    def tick(self, frames, window_s, expected_fps):
+        if window_s <= 0:
+            return None
+        if expected_fps is None or expected_fps <= 0:
+            self._below = 0
+            self._above = 0
+            self._last_expected = None
+            return None
+        if frames <= 0 and not self._started:
+            # Startup / preroll — nothing rendered yet, nothing to judge.
+            self._below = 0
+            self._above = 0
+            self._last_expected = expected_fps
+            return None
+        if frames > 0:
+            self._started = True
+        if self._last_expected is not None and expected_fps != self._last_expected:
+            self._below = 0
+            self._above = 0
+        self._last_expected = expected_fps
+
+        achieved = frames / window_s
+        if achieved < self.lag_ratio * expected_fps:
+            self._below += 1
+            self._above = 0
+            if not self.lagging and self._below >= self.trip_windows:
+                self.lagging = True
+                return ("lag", achieved, expected_fps)
+        elif achieved >= self.recover_ratio * expected_fps:
+            self._above += 1
+            self._below = 0
+            if self.lagging and self._above >= self.trip_windows:
+                self.lagging = False
+                return ("recovered", achieved, expected_fps)
+        else:
+            # Inside the hysteresis band: neither streak advances.
+            self._below = 0
+            self._above = 0
+        return None

--- a/packages/engine/src/child-process/render_lag.py
+++ b/packages/engine/src/child-process/render_lag.py
@@ -24,16 +24,24 @@ Rules:
   `lag_ratio * expected`; recovery clears it after `trip_windows` consecutive
   windows at or above `recover_ratio * expected`. The gap between the two
   ratios is the hysteresis band that stops flapping around the threshold.
+- Sustained sink drops ALSO count as lag: a pipeline can present just above
+  the lag ratio while steadily shedding late frames (field case 2026-08-02:
+  presented 88 %, 5 fps dropped as late, visibly stuttering for minutes with
+  the monitor silent — 0.88 sits inside the hysteresis band). A window with
+  `dropped_fps > drop_ratio * expected` counts toward the lag streak, and
+  recovery additionally requires drops at or below half that rate.
 - A change in `expected_fps` (mid-stream format switch) resets the streaks —
   windows straddling a switch would judge the old rate against the new caps.
 """
 
 
 class RenderLagMonitor:
-    def __init__(self, lag_ratio=0.85, recover_ratio=0.95, trip_windows=3):
+    def __init__(self, lag_ratio=0.85, recover_ratio=0.95, trip_windows=3,
+                 drop_ratio=0.05):
         self.lag_ratio = lag_ratio
         self.recover_ratio = recover_ratio
         self.trip_windows = trip_windows
+        self.drop_ratio = drop_ratio
         self.lagging = False
         self._below = 0
         self._above = 0
@@ -48,7 +56,7 @@ class RenderLagMonitor:
         # mid-lag should not synthesize a "recovered" event (recovery must be
         # measured), and it doesn't un-happen that frames have flowed.
 
-    def tick(self, frames, window_s, expected_fps):
+    def tick(self, frames, window_s, expected_fps, dropped_fps=0.0):
         if window_s <= 0:
             return None
         if expected_fps is None or expected_fps <= 0:
@@ -70,13 +78,15 @@ class RenderLagMonitor:
         self._last_expected = expected_fps
 
         achieved = frames / window_s
-        if achieved < self.lag_ratio * expected_fps:
+        dropping = dropped_fps > self.drop_ratio * expected_fps
+        if achieved < self.lag_ratio * expected_fps or dropping:
             self._below += 1
             self._above = 0
             if not self.lagging and self._below >= self.trip_windows:
                 self.lagging = True
                 return ("lag", achieved, expected_fps)
-        elif achieved >= self.recover_ratio * expected_fps:
+        elif (achieved >= self.recover_ratio * expected_fps
+              and dropped_fps <= 0.5 * self.drop_ratio * expected_fps):
             self._above += 1
             self._below = 0
             if self.lagging and self._above >= self.trip_windows:

--- a/packages/engine/src/child-process/render_lag_test.py
+++ b/packages/engine/src/child-process/render_lag_test.py
@@ -96,6 +96,42 @@ evs = ticks(m, [100, 100, 100], expected=50.0)
 check("recovery after reset is measured, not assumed",
       len(evs) == 1 and evs[0][0] == "recovered")
 
+# --- sustained sink drops trip lag even above the presented-fps ratio -------
+# Field case 2026-08-02: presented 44/50 fps (ratio 0.88, inside the
+# hysteresis band) with 5 fps steadily dropped as late — stuttered for
+# minutes with no event.
+m = RenderLagMonitor()
+ticks(m, [100])                                      # healthy start
+evs = []
+for _ in range(3):
+    ev = m.tick(88, 2.0, 50.0, dropped_fps=5.0)
+    if ev:
+        evs.append(ev)
+check("sustained drops trip lag", len(evs) == 1 and evs[0][0] == "lag")
+
+# --- recovery requires drops to clear, not just presented fps ---------------
+evs = []
+for _ in range(4):
+    ev = m.tick(100, 2.0, 50.0, dropped_fps=5.0)     # presents fine, still drops
+    if ev:
+        evs.append(ev)
+check("no recovery while still dropping", evs == [] and m.lagging)
+evs = []
+for _ in range(3):
+    ev = m.tick(100, 2.0, 50.0, dropped_fps=0.0)
+    if ev:
+        evs.append(ev)
+check("recovery once drops clear", len(evs) == 1 and evs[0][0] == "recovered")
+
+# --- transient drop blips do not trip ---------------------------------------
+m = RenderLagMonitor()
+ticks(m, [100])
+m.tick(95, 2.0, 50.0, dropped_fps=4.0)
+m.tick(100, 2.0, 50.0, dropped_fps=0.0)              # blip over — streak resets
+m.tick(95, 2.0, 50.0, dropped_fps=4.0)
+m.tick(95, 2.0, 50.0, dropped_fps=4.0)
+check("transient drop blips stay silent", not m.lagging)
+
 print()
 if _failures:
     print(f"{len(_failures)} FAILED")

--- a/packages/engine/src/child-process/render_lag_test.py
+++ b/packages/engine/src/child-process/render_lag_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Self-checking tests for render_lag.py (no GStreamer, no engine).
+
+Run:  python3 render_lag_test.py
+"""
+import sys
+
+from render_lag import RenderLagMonitor
+
+_failures = []
+
+
+def check(name, cond):
+    print(("PASS " if cond else "FAIL ") + name)
+    if not cond:
+        _failures.append(name)
+
+
+def ticks(mon, seq, expected=50.0, window=2.0):
+    """Feed per-window frame counts; return list of non-None events."""
+    out = []
+    for frames in seq:
+        ev = mon.tick(frames, window, expected)
+        if ev:
+            out.append(ev)
+    return out
+
+
+# --- trips only after 3 consecutive lagging windows -------------------------
+m = RenderLagMonitor()
+# 50 fps expected over 2 s windows → 100 frames = keeping up, 50 = half rate.
+evs = ticks(m, [100, 50, 50])
+check("no event before third lagging window", evs == [])
+evs = ticks(m, [50])
+check("lag trips on third consecutive window", len(evs) == 1 and evs[0][0] == "lag")
+check("lag payload carries achieved fps", abs(evs[0][1] - 25.0) < 0.01)
+check("lag payload carries expected fps", evs[0][2] == 50.0)
+check("monitor latched lagging", m.lagging)
+
+# --- a good window mid-streak resets the trip counter -----------------------
+m = RenderLagMonitor()
+evs = ticks(m, [50, 50, 100, 50, 50])
+check("interrupted streak does not trip", evs == [] and not m.lagging)
+
+# --- recovery needs 3 consecutive good windows, then emits once -------------
+m = RenderLagMonitor()
+ticks(m, [50, 50, 50])          # trip
+evs = ticks(m, [100, 100])
+check("no recovery before third good window", evs == [])
+evs = ticks(m, [100])
+check("recovered emits on third good window", len(evs) == 1 and evs[0][0] == "recovered")
+check("monitor unlatched", not m.lagging)
+evs = ticks(m, [100, 100, 100])
+check("no duplicate recovered events", evs == [])
+
+# --- hysteresis band (between 0.85 and 0.95) advances neither streak --------
+m = RenderLagMonitor()
+ticks(m, [50, 50])              # two lagging windows
+evs = ticks(m, [90])            # 45 fps = 0.90 × expected → in the band
+check("band window emits nothing", evs == [])
+evs = ticks(m, [50, 50, 50])    # streak restarted from zero
+check("band window reset the lag streak", len(evs) == 1 and evs[0][0] == "lag")
+
+# --- zero-frame windows BEFORE first frame are startup, not lag -------------
+m = RenderLagMonitor()
+evs = ticks(m, [0, 0, 0, 0])
+check("preroll windows never trip lag", evs == [] and not m.lagging)
+
+# --- zero-frame windows AFTER frames flowed are the worst lag ---------------
+# A starving sink behind a flowing source: decoder sheds so much upstream
+# that whole windows come up empty. Alternating 0/1-frame windows must
+# accumulate, not reset (the .211 grey-smear case that evaded detection).
+m = RenderLagMonitor()
+ticks(m, [100])                 # started, keeping up
+evs = ticks(m, [0, 1, 0])
+check("post-start starvation trips lag", len(evs) == 1 and evs[0][0] == "lag")
+check("lag payload reports near-zero achieved", evs[0][1] < 1.0)
+
+# --- unknown expected fps disables judgement --------------------------------
+m = RenderLagMonitor()
+evs = ticks(m, [50, 50, 50], expected=0)
+check("no events without a declared framerate", evs == [] and not m.lagging)
+
+# --- expected-fps change (format switch) resets streaks ---------------------
+m = RenderLagMonitor()
+ticks(m, [50, 50], expected=50.0)
+evs = ticks(m, [50], expected=25.0)   # 25 fps achieved vs 25 expected = fine
+check("format switch does not trip on stale streak", evs == [] and not m.lagging)
+
+# --- caps switch mid-lag does not synthesize recovery -----------------------
+m = RenderLagMonitor()
+ticks(m, [50, 50, 50], expected=50.0)   # lagging
+m.reset()
+check("reset keeps the lag latch", m.lagging)
+evs = ticks(m, [100, 100, 100], expected=50.0)
+check("recovery after reset is measured, not assumed",
+      len(evs) == 1 and evs[0][0] == "recovered")
+
+print()
+if _failures:
+    print(f"{len(_failures)} FAILED")
+    sys.exit(1)
+print("all render_lag tests passed")

--- a/packages/engine/src/plugins/GstPluginBase.runner.test.ts
+++ b/packages/engine/src/plugins/GstPluginBase.runner.test.ts
@@ -107,3 +107,18 @@ describe('GstPluginBase.spawnRunnerProcess health wiring', () => {
         expect(() => module.spawn({ label: 'r', command: 'x' })).toThrow(/processManager/);
     });
 });
+
+describe('getState error serialization', () => {
+    it('a cleared error is null, never undefined — JSON must carry the key', () => {
+        // Per-field mergers downstream (manager-ui socket store: `if ('error'
+        // in s)`) never clear a field whose key was dropped by JSON. Field
+        // case 2026-08-02: "can't keep up (0/50 fps)" displayed on a healthy
+        // module across engine restarts.
+        const { module } = makeModule();
+        module.setHealth('warning', 'Video output cannot keep up');
+        expect(module.getState().error).toBe('Video output cannot keep up');
+        module.setHealth('ok');
+        expect(module.getState().error).toBeNull();
+        expect('error' in JSON.parse(JSON.stringify(module.getState()))).toBe(true);
+    });
+});

--- a/packages/engine/src/plugins/GstPluginBase.ts
+++ b/packages/engine/src/plugins/GstPluginBase.ts
@@ -190,6 +190,10 @@ export abstract class GstPluginBase extends EventEmitter implements PluginModule
         await this.childProcess.start(desc);
         this.running = true;
         this.health = 'ok';
+        // A successful start supersedes whatever error text the previous
+        // incarnation left behind — without this the stale text rides along
+        // with health='ok' forever ("healthy but shows an old error").
+        this.error = undefined;
         this.emit('stateChange', this.getState());
 
         // For data-mode pipelines with a null-sink, start a separate VU metering process
@@ -291,7 +295,10 @@ export abstract class GstPluginBase extends EventEmitter implements PluginModule
             // is live) reach the UI.
             liveUpdatableParams: this.getLiveUpdatableParams(),
             vuData: this.vuData,
-            error: this.error,
+            // null (not undefined): a cleared error must survive JSON — the
+            // key vanishes for undefined and per-field mergers (manager-ui
+            // socket store) keep the stale text forever.
+            error: this.error ?? null,
             statusData: this.statusData,
             dynamicStatusSections: this.dynamicStatusSections,
             badges: Array.from(this.badges.values()),

--- a/packages/engine/src/plugins/PluginModule.ts
+++ b/packages/engine/src/plugins/PluginModule.ts
@@ -274,6 +274,21 @@ export interface PipelineDescription {
      */
     tsProbe?: TsProbeRunnerConfig;
     /**
+     * Report-only render keep-up watch. The runner reads the named sink's
+     * GstBaseSink `stats` (rendered/dropped) per 2 s window and compares the
+     * PRESENTED rate against the framerate the negotiated caps declare —
+     * counting pad arrivals instead was a proven blind spot (a sink can
+     * receive 50 fps and silently discard a third of it; observed on Pi 4
+     * waylandsink, 2026-08-01). Pad arrivals still gate the judgement: a
+     * window with no arrivals is the stall watchdog's condition, not lag,
+     * and sinks without `stats` fall back to arrival counting. On lag it
+     * emits `renderwatch:lag` `{achievedFps, expectedFps, droppedFps}`;
+     * when the rate is back it emits `renderwatch:recovered`. Hysteresis
+     * (0.85 trip / 0.95 recover, 3 consecutive windows) lives runner-side
+     * in render_lag.py. Never affects routing.
+     */
+    renderWatch?: RenderWatchRunnerConfig;
+    /**
      * Carry the SOURCE PES timeline through the named `tsdemux` (2026-07-23
      * incident / TodoNotes:20). tsdemux erases the source timeline (buffer PTS
      * rebased ~0 per incarnation), so a transcoding pipeline's output mux
@@ -298,6 +313,12 @@ export interface PreserveSourceTimelineConfig {
 export interface TsProbeRunnerConfig {
     /** `name=` of the tap appsink in `pipeline` receiving the muxed TS. */
     appsink: string;
+}
+
+/** Render keep-up watch config — see PipelineDescription.renderWatch. */
+export interface RenderWatchRunnerConfig {
+    /** `name=` of the video sink element in `pipeline` to watch. */
+    sink: string;
 }
 
 /** librist runner config — see PipelineDescription.rist. */

--- a/packages/engine/src/routing/MediaRouter.test.ts
+++ b/packages/engine/src/routing/MediaRouter.test.ts
@@ -632,6 +632,57 @@ describe('MediaRouter', () => {
         expect(router.getConnections()).toHaveLength(1);
     });
 
+    it('reexecuteIncomingPwLinks re-links edges into a rebuilt sink node in place', async () => {
+        // Field case 2026-08-02: an HDMI power-cycle recreated audio-output's
+        // remap-sink as a NEW PipeWire node; the decoder→output pw-link died
+        // with the old node and nothing re-created it — silent output, all
+        // modules "running". The reconnect hook re-executes the edge in place
+        // (record kept, handle replaced).
+        const pipeWire = {
+            pwUnlinkAllBetween: vi.fn().mockResolvedValue(undefined),
+            listPorts: vi.fn().mockResolvedValue(['node:port_FL']),
+            pwLink: vi.fn().mockResolvedValue(1),
+            pwUnlinkByName: vi.fn().mockResolvedValue(undefined),
+            pwUnlink: vi.fn().mockResolvedValue(undefined),
+        };
+        const moduleGetter = vi.fn().mockImplementation((id: string) => {
+            if (id === 'dec')
+                return {
+                    running: true,
+                    getPipeWireNodeForPort: () => undefined,
+                    getPipeWireNodes: () => ({ source: 'dec.monitor' }),
+                };
+            if (id === 'out')
+                return {
+                    running: true,
+                    getPipeWireNodeForPort: () => undefined,
+                    getPipeWireNodes: () => ({ sink: 'out' }),
+                };
+            return undefined;
+        });
+        router.setDependencies(pipeWire as any, moduleGetter as any);
+        router.registerPorts('dec', [
+            { id: 'audio-out', direction: 'output', streamType: 'audio/pcm', label: 'Out' },
+        ]);
+        router.registerPorts('out', [
+            { id: 'audio-in', direction: 'input', streamType: 'audio/pcm', label: 'In' },
+        ]);
+        await router.createConnection('dec', 'audio-out', 'out', 'audio-in');
+        expect(pipeWire.pwLink).toHaveBeenCalledTimes(1);
+
+        await router.reexecuteIncomingPwLinks('out');
+
+        // Old link torn down, edge re-executed, record still present.
+        expect(pipeWire.pwUnlinkByName).toHaveBeenCalled();
+        expect(pipeWire.pwLink).toHaveBeenCalledTimes(2);
+        expect(router.getConnections()).toHaveLength(1);
+
+        // No pw-link edges into 'dec' → no-op.
+        pipeWire.pwLink.mockClear();
+        await router.reexecuteIncomingPwLinks('dec');
+        expect(pipeWire.pwLink).not.toHaveBeenCalled();
+    });
+
     it('createConnection throws (not silently drops) when pw-link ports never appear — so the cascade re-link retries', async () => {
         // Regression guard paired with invalidateOutgoingPwLinks: after the
         // record is dropped, the re-apply must be retryable. A recreated

--- a/packages/engine/src/routing/MediaRouter.ts
+++ b/packages/engine/src/routing/MediaRouter.ts
@@ -292,6 +292,40 @@ export class MediaRouter {
         }
     }
 
+    /**
+     * Re-execute live pw-link edges INTO `moduleId` after it rebuilt its
+     * PipeWire node. A device hot-plug recreates a remap-sink as a NEW node,
+     * and the pw-links from upstream monitors died with the old one — the
+     * connection records are still live, so re-run the executor in place
+     * (same teardown/execute pattern as updateChannelMap). Field case
+     * 2026-08-02: HDMI monitor power-cycle → audio-output remap-sink
+     * recreated → decoder→output link never re-created → silent output with
+     * every module reporting running.
+     */
+    async reexecuteIncomingPwLinks(moduleId: string): Promise<void> {
+        const conns = this.getConnections().filter(
+            (c) => c.sinkModuleId === moduleId && this.handles.get(c.id)?.type === 'pw-link',
+        );
+        for (const conn of conns) {
+            const handle = this.handles.get(conn.id);
+            log.info({ connectionId: conn.id }, 'Re-executing pw-link into rebuilt node');
+            if (handle && this.executor) {
+                // Best-effort: the old node is gone, so the unlink usually fails.
+                await this.executor.teardown(handle, conn, true);
+                this.handles.delete(conn.id);
+            }
+            try {
+                const newHandle = await this.executor?.execute(conn);
+                if (newHandle) this.handles.set(conn.id, newHandle);
+            } catch (err) {
+                log.error(
+                    { err, connectionId: conn.id },
+                    'Failed to re-execute pw-link after node rebuild',
+                );
+            }
+        }
+    }
+
     async updateChannelMap(connId: string, channelMap?: ChannelMapEntry[]): Promise<void> {
         const conn = this.connections.get(connId);
         if (!conn) {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -387,8 +387,14 @@ export interface ModuleRuntimeState {
      * subtitle languages). The settings panel renders these as multi-selects.
      */
     fieldOptions?: Record<string, Array<{ value: string; label: string }>>;
-    /** Error message if health is "error". */
-    error?: string;
+    /**
+     * Error/warning message backing the health state. `null` means
+     * explicitly cleared — it must survive JSON serialization (undefined
+     * keys are dropped, and per-field mergers downstream would keep stale
+     * text forever; field case 2026-08-02: "can't keep up (0/50 fps)"
+     * displayed on a healthy module across engine restarts).
+     */
+    error?: string | null;
     /** Non-fatal warnings (e.g. stream layout mismatches). */
     warnings?: string[];
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -674,6 +674,24 @@ interface PipelineDescription {
      */
     tsProbe?: TsProbeRunnerConfig;
     /**
+     * Report-only render keep-up watch (render_lag.py): the runner reads the
+     * named sink's GstBaseSink `stats` (rendered/dropped counters) per 2 s
+     * window and compares the PRESENTED rate against the framerate the
+     * negotiated caps declare. Judging pad arrivals instead is a proven blind
+     * spot — a sink can receive the full source rate and still discard a
+     * third of it internally (waylandsink under a compositor that misses
+     * vblanks; observed on Pi 4, 2026-08-01). Pad arrivals gate the
+     * judgement (no arrivals = stall watchdog's condition, not lag), and
+     * sinks without `stats` fall back to arrival counting. When the chain
+     * demonstrably can't sustain the source rate it emits `renderwatch:lag`
+     * `{achievedFps, expectedFps, droppedFps}`; on sustained recovery,
+     * `renderwatch:recovered`. Hysteresis runner-side (0.85 trip / 0.95
+     * recover, 3 consecutive windows). The sink must be NAMED in the
+     * pipeline string — see `video-player` (warns the operator to lower the
+     * stream or display resolution).
+     */
+    renderWatch?: RenderWatchRunnerConfig;
+    /**
      * Carry the SOURCE PES timeline through the named tsdemux. tsdemux erases
      * the source timeline (buffer PTS rebased ~0 per incarnation), so a
      * transcoding pipeline's output mux stamps a fresh timeline every

--- a/plugins/audio-decoder/engine/AudioDecoderModule.test.ts
+++ b/plugins/audio-decoder/engine/AudioDecoderModule.test.ts
@@ -113,12 +113,12 @@ describe('AudioDecoderModule.buildPipeline', () => {
         expect(desc!.pipeline).not.toContain('ts-offset');
     });
 
-    it('lowLatencySync → sync=true + small ring + max-lateness=-1 (arrival-anchored, never-silent)', () => {
+    it('lowLatencySync → sync=true + floored ring + max-lateness=-1 (arrival-anchored, never-silent)', () => {
         const { module } = makeModule();
         const desc = module.buildPipeline({ lowLatencySync: true });
         expect(desc!.pipeline).toContain('pulsesink device=MR_PW_dec-1 sync=true');
         expect(desc!.pipeline).not.toContain('provide-clock=false');
-        expect(desc!.pipeline).toContain('buffer-time=50000');
+        expect(desc!.pipeline).toContain('buffer-time=200000');
         expect(desc!.pipeline).not.toContain('ts-offset');
         expect(desc!.pipeline).toContain('max-lateness=-1');
         expect(desc!.clockSync).toBeUndefined();
@@ -207,9 +207,12 @@ describe('AudioDecoderModule.buildPipeline', () => {
         expect(module.buildPipeline({ sinkBufferMs: 10 })!.pipeline).toContain(
             'buffer-time=80000',
         );
-        // lowLatencySync keeps its own small fixed ring regardless of sinkBufferMs.
+        // lowLatencySync honours sinkBufferMs with a 100 ms floor — the old
+        // hardcoded 50 ms ring xrunned on the field Pi 4 (audible dropouts).
         const lls = module.buildPipeline({ lowLatencySync: true, sinkBufferMs: 500 });
-        expect(lls!.pipeline).toContain('buffer-time=50000');
+        expect(lls!.pipeline).toContain('buffer-time=500000');
+        const llsThin = module.buildPipeline({ lowLatencySync: true, sinkBufferMs: 80 });
+        expect(llsThin!.pipeline).toContain('buffer-time=100000');
     });
 });
 

--- a/plugins/audio-decoder/engine/AudioDecoderModule.ts
+++ b/plugins/audio-decoder/engine/AudioDecoderModule.ts
@@ -186,21 +186,24 @@ export class AudioDecoderModule extends GstPluginBase {
         const syncOffsetMs = Math.max(0, Number(config.syncOffsetMs ?? 0));
         const sinkSync = clockSync || lowLatencySync ? 'true' : 'false';
         const provideClock = clockSync ? ' provide-clock=false' : '';
-        // Small pa ring (50 ms vs the default 200 ms): with sync=true the ring
-        // fill is bounded playout delay, not a reservoir — the upstream
-        // non-leaky dejitter queue holds the bursts. syncOffsetMs defaults to
-        // 0: PES-cluster arrivals then render slightly "late" (immediately,
-        // thanks to max-lateness=-1), anchoring audio at arrival ≈ the
-        // smallest possible standing latency. Raise it only if underflow
-        // gaps appear (it trades latency for pacing headroom).
+        // syncOffsetMs defaults to 0: PES-cluster arrivals then render
+        // slightly "late" (immediately, thanks to max-lateness=-1), anchoring
+        // audio at arrival ≈ the smallest possible standing latency. Raise it
+        // toward the burst spacing for genuine pacing (field 2026-08-02:
+        // 250 ms plays steadily).
         const sinkTiming = lowLatencySync
             ? `${syncOffsetMs > 0 ? ` ts-offset=${syncOffsetMs * 1_000_000}` : ''} max-lateness=-1`
             : ' max-lateness=200000000';
 
-        // pa ring size (µs) for the default sync=false path — see the
-        // pulsesink comment below. Clamped 80–1000 ms.
+        // pa ring size (µs). Clamped 80–1000 ms; the paced (lowLatencySync)
+        // path floors it at 100 ms — an earlier hardcoded 50 ms ring xrunned
+        // audibly on the field Pi 4 (pw-top ERR incrementing, dropouts "here
+        // and there"): with sync=true the anchor is ts-offset, so ring depth
+        // is scheduling margin against pw-pulse quantum jitter, not
+        // proportional standing latency.
         const sinkBufferUs =
             Math.max(80, Math.min(1000, Number(config.sinkBufferMs ?? 200))) * 1000;
+        const pacedSinkBufferUs = Math.max(100_000, sinkBufferUs);
 
         const parts = [
             // Post-tsdemux dejitter buffer — NON-LEAKY (leaky=0), sized to at
@@ -239,7 +242,7 @@ export class AudioDecoderModule extends GstPluginBase {
             // drops a frame only when it arrives *already* >200 ms late
             // (post-stall recovery, not steady state);
             // `processing-deadline=100000000`.
-            `pulsesink device=${this.pwNodeName} sync=${sinkSync}${provideClock} slave-method=${slaveMethod} processing-deadline=100000000 buffer-time=${lowLatencySync ? 50000 : sinkBufferUs}${sinkTiming}`,
+            `pulsesink device=${this.pwNodeName} sync=${sinkSync}${provideClock} slave-method=${slaveMethod} processing-deadline=100000000 buffer-time=${lowLatencySync ? pacedSinkBufferUs : sinkBufferUs}${sinkTiming}`,
         ];
         const pipeline = parts.join(' ! ');
 

--- a/plugins/audio-output/engine/AudioOutputModule.test.ts
+++ b/plugins/audio-output/engine/AudioOutputModule.test.ts
@@ -116,6 +116,27 @@ describe('AudioOutputModule hot-plug recovery', () => {
         await module.onStop();
     });
 
+    it('re-executes incoming pw-links after the remap-sink is rebuilt', async () => {
+        // Field case 2026-08-02: HDMI power-cycle → new remap-sink node; the
+        // decoder→output pw-link died with the old node and playback stayed
+        // silent. The reconnect hook must ask the router to re-link.
+        const { module, pw, services, config } = createModule(true);
+        const reexec = vi.fn(async () => {});
+        services.mediaRouter = { reexecuteIncomingPwLinks: reexec } as any;
+        await module.onInit(config, services);
+        await module.onStart();
+        expect(reexec).not.toHaveBeenCalled();
+
+        pw.setPresent(false);
+        await tickWatchdog(module);
+        pw.setPresent(true);
+        await tickWatchdog(module);
+
+        expect(reexec).toHaveBeenCalledTimes(1);
+        expect(reexec).toHaveBeenCalledWith('spk-test-001');
+        await module.onStop();
+    });
+
     it('loads a fresh remap-sink after disconnect/reconnect cycle', async () => {
         const { module, pw, services, config } = createModule(true);
         await module.onInit(config, services);

--- a/plugins/audio-output/engine/AudioOutputModule.ts
+++ b/plugins/audio-output/engine/AudioOutputModule.ts
@@ -135,6 +135,13 @@ export class AudioOutputModule extends GstPluginBase {
             );
         }
         await this.bringUpRemapSinkAndPipeline(resolved.channels, resolved.rate);
+        // The remap-sink is a NEW PipeWire node — every routed pw-link into
+        // the old one died with it. Re-execute them or the module sits IDLE
+        // with zero inbound links, silent while reporting running (field
+        // 2026-08-02: HDMI monitor power-cycle).
+        if (this.services?.mediaRouter?.reexecuteIncomingPwLinks) {
+            await this.services.mediaRouter.reexecuteIncomingPwLinks(this.services.instanceId);
+        }
     }
 
     /**

--- a/plugins/rist-input/engine/RistInputModule.test.ts
+++ b/plugins/rist-input/engine/RistInputModule.test.ts
@@ -196,3 +196,81 @@ describe('RistInputModule rist:stats rendering', () => {
         expect(setStatusData).not.toHaveBeenCalled();
     });
 });
+
+describe('RistInputModule link health (recovered-loss storms)', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    function storm(quality: number, missing = 150, received = 850) {
+        return {
+            'receiver-stats': {
+                flowinstant: {
+                    stats: { received, missing, quality, lost: 0 },
+                    peers: [{ id: 1, stats: { avg_rtt: 210.4 } }],
+                },
+            },
+        };
+    }
+
+    function makeHealthModule() {
+        const { module, ...rest } = makeModule();
+        module.setHealth = vi.fn();
+        return { module, setHealth: module.setHealth as ReturnType<typeof vi.fn>, ...rest };
+    }
+
+    it('renders the recovered-loss rate in the flow stats', () => {
+        const { module, setStatusData } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(85, 150, 850));
+        expect(setStatusData).toHaveBeenCalledWith(
+            'stats',
+            expect.objectContaining({ loss: '15.0', rtt: '210.40' }),
+        );
+    });
+
+    it('warns only after 3 consecutive low-quality windows', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).not.toHaveBeenCalled();
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).toHaveBeenCalledWith(
+            'warning',
+            expect.stringContaining('recovering 15% packet loss'),
+        );
+    });
+
+    it('a single good window resets the warn streak (no flapping into warning)', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(100, 0));
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).not.toHaveBeenCalled();
+    });
+
+    it('clears its own warning only after 5 consecutive clean windows', () => {
+        const { module, setHealth } = makeHealthModule();
+        for (let i = 0; i < 3; i++) module.onPluginEvent('rist:stats', storm(80));
+        module.health = 'warning';
+        for (let i = 0; i < 4; i++) module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).not.toHaveBeenCalledWith('ok');
+        module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).toHaveBeenLastCalledWith('ok');
+    });
+
+    it('never clears a warning it does not own', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.health = 'warning'; // someone else's warning, linkWarnActive false
+        for (let i = 0; i < 6; i++) module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).not.toHaveBeenCalled();
+    });
+
+    it('mid-band quality (85–95) keeps an active warning latched', () => {
+        const { module, setHealth } = makeHealthModule();
+        for (let i = 0; i < 3; i++) module.onPluginEvent('rist:stats', storm(80));
+        module.health = 'warning';
+        setHealth.mockClear();
+        for (let i = 0; i < 10; i++) module.onPluginEvent('rist:stats', storm(90, 50, 950));
+        expect(setHealth).not.toHaveBeenCalledWith('ok');
+    });
+});

--- a/plugins/rist-input/engine/RistInputModule.ts
+++ b/plugins/rist-input/engine/RistInputModule.ts
@@ -30,8 +30,32 @@ const RIST_APPSRC = 'ristsrc';
  * kept for full feature support: per-link weight, cname, main/advanced
  * profiles, encryption.
  */
+/**
+ * Link-health hysteresis on librist's quality metric (100 = no loss). RIST
+ * recovers lost packets via retransmission, so a badly degraded link can carry
+ * a perfect stream — invisible unless surfaced here. Field case, 2026-08-02:
+ * production-hours loss storms of 10–20 % (all recovered, `lost=0`) were the
+ * prime suspect behind intermittent video delivery dips, yet every ad-hoc
+ * link check came back clean because only unrecovered loss is observable.
+ * Warn after WARN_STREAK consecutive low-quality stats windows; clear only
+ * after CLEAR_STREAK clean ones so a flapping link doesn't flap the health.
+ */
+const QUALITY_WARN = 85;
+const QUALITY_CLEAR = 95;
+const WARN_STREAK = 3;
+const CLEAR_STREAK = 5;
+
 export class RistInputModule extends GstPluginBase {
+    private linkWarnActive = false;
+    private lowStreak = 0;
+    private okStreak = 0;
+
     async onStart(): Promise<void> {
+        // A rebuilt receiver re-measures from scratch — stale hysteresis must
+        // not suppress or fake a link warning.
+        this.linkWarnActive = false;
+        this.lowStreak = 0;
+        this.okStreak = 0;
         // Assign the bus output channel before buildPipeline reads it back.
         // The port is the channel identity (busout_<port> tee under unixfd).
         if (this.services?.mediaRouter) {
@@ -102,19 +126,34 @@ export class RistInputModule extends GstPluginBase {
 
         const s = flow.stats;
 
-        // Flow-level stats (aggregate across all peers)
-        this.setStatusData('stats', {
-            received: Number(s.received ?? 0),
-            dropped: Number(s.dropped_late ?? 0),
-            recovered: Number(s.recovered_total ?? 0),
-            lost: Number(s.lost ?? 0),
-            rtt: '—',
-        });
+        // Recovered-loss rate this stats window: what fraction of the wire
+        // went missing before retransmission repaired it. `lost` only counts
+        // UNrecovered packets, so this is the metric that exposes a degraded
+        // link that still delivers a perfect stream.
+        const missing = Number(s.missing ?? 0);
+        const received = Number(s.received ?? 0);
+        const lossPct = received + missing > 0 ? (100 * missing) / (received + missing) : 0;
 
-        // Per-peer stats and dynamic sections
         const peers = flow.peers as
             | Array<{ id?: number; cname?: string; stats?: Record<string, unknown> }>
             | undefined;
+        const firstPeer = peers?.[0]?.stats;
+        const rtt =
+            typeof firstPeer?.avg_rtt === 'number'
+                ? (firstPeer.avg_rtt as number).toFixed(2)
+                : String(firstPeer?.rtt ?? '—');
+
+        // Flow-level stats (aggregate across all peers)
+        this.setStatusData('stats', {
+            received,
+            dropped: Number(s.dropped_late ?? 0),
+            recovered: Number(s.recovered_total ?? 0),
+            loss: lossPct.toFixed(1),
+            lost: Number(s.lost ?? 0),
+            rtt,
+        });
+
+        // Per-peer stats and dynamic sections
         if (peers && peers.length > 0) {
             const peerFields = [
                 { key: 'quality', label: 'Quality', unit: '%' },
@@ -153,24 +192,10 @@ export class RistInputModule extends GstPluginBase {
                     ];
                 }
             }
-
-            // Use first peer's RTT for the flow-level display
-            const firstPeer = peers[0]?.stats;
-            if (firstPeer) {
-                this.setStatusData('stats', {
-                    received: Number(s.received ?? 0),
-                    dropped: Number(s.dropped_late ?? 0),
-                    recovered: Number(s.recovered_total ?? 0),
-                    lost: Number(s.lost ?? 0),
-                    rtt:
-                        typeof firstPeer.avg_rtt === 'number'
-                            ? `${(firstPeer.avg_rtt as number).toFixed(2)}`
-                            : String(firstPeer.rtt ?? '—'),
-                });
-            }
         }
 
         const quality = Number(s.quality ?? 0);
+        this.applyLinkHealth(quality, lossPct, rtt);
         this.setBadge('quality', {
             icon: 'signal',
             text: `${quality}%`,
@@ -184,6 +209,34 @@ export class RistInputModule extends GstPluginBase {
             text: `${peerCount}`,
             color: peerCount > 0 ? '#10b981' : '#6b7280',
         });
+    }
+
+    /** See the hysteresis constants above for why this exists. */
+    private applyLinkHealth(quality: number, lossPct: number, rtt: string): void {
+        if (quality < QUALITY_WARN) {
+            this.lowStreak++;
+            this.okStreak = 0;
+        } else if (quality >= QUALITY_CLEAR) {
+            this.okStreak++;
+            this.lowStreak = 0;
+        } else {
+            // In-between band: neither degrades further nor proves recovery.
+            this.lowStreak = 0;
+            this.okStreak = 0;
+        }
+        if (this.lowStreak >= WARN_STREAK) {
+            this.linkWarnActive = true;
+            this.setHealth(
+                'warning',
+                `RIST link degraded — recovering ${lossPct.toFixed(0)}% packet loss ` +
+                    `(RTT ${rtt} ms); stream still intact`,
+            );
+        } else if (this.okStreak >= CLEAR_STREAK && this.linkWarnActive) {
+            // Only clear health WE degraded — never stomp a warning another
+            // path owns.
+            if (this.health === 'warning') this.setHealth('ok');
+            this.linkWarnActive = false;
+        }
     }
 }
 

--- a/plugins/rist-input/package.json
+++ b/plugins/rist-input/package.json
@@ -2,7 +2,7 @@
     "name": "@media-router/plugin-rist-input",
     "version": "2.0.0",
     "private": true,
-    "description": "RIST input \u2014 receives MPEG-TS stream over RIST protocol with bonding support",
+    "description": "RIST input — receives MPEG-TS stream over RIST protocol with bonding support",
     "mediaRouter": {
         "pluginId": "rist-input",
         "displayName": "RIST Input",
@@ -152,6 +152,11 @@
                     {
                         "key": "recovered",
                         "label": "Recovered"
+                    },
+                    {
+                        "key": "loss",
+                        "label": "Loss (recovered)",
+                        "unit": "%"
                     },
                     {
                         "key": "lost",

--- a/plugins/ts-splitter/engine/TsSplitterModule.ts
+++ b/plugins/ts-splitter/engine/TsSplitterModule.ts
@@ -177,6 +177,9 @@ export class TsSplitterModule extends GstPluginBase {
                 inputSocketPath: upstream.socketPath,
                 tsId: (this.config.tsId as number) ?? 1,
                 outputs,
+                // Fan-out coalescing window; 0 disables batching for
+                // ultra-low-latency chains (see the schema description).
+                busBatchMs: this.config.busBatchMs as number | undefined,
             }),
             autoRestart: true,
             stdin: true,

--- a/plugins/ts-splitter/engine/nativeRunner.test.ts
+++ b/plugins/ts-splitter/engine/nativeRunner.test.ts
@@ -20,6 +20,20 @@ describe('buildSpawnArgs', () => {
             '--out', '0x1f0:busout_41001',
         ]);
     });
+
+    it('omits --flush-ms when busBatchMs is unset (runner default = 20 ms)', () => {
+        const args = buildSpawnArgs({ inputSocketPath: '/s', outputs: [] });
+        expect(args).not.toContain('--flush-ms');
+    });
+
+    it('passes busBatchMs through as --flush-ms, including 0 (batching off)', () => {
+        expect(
+            buildSpawnArgs({ inputSocketPath: '/s', outputs: [], busBatchMs: 5 }),
+        ).toEqual(expect.arrayContaining(['--flush-ms', '5']));
+        expect(
+            buildSpawnArgs({ inputSocketPath: '/s', outputs: [], busBatchMs: 0 }),
+        ).toEqual(expect.arrayContaining(['--flush-ms', '0']));
+    });
 });
 
 describe('dispatchRunnerEvent', () => {

--- a/plugins/ts-splitter/engine/nativeRunner.ts
+++ b/plugins/ts-splitter/engine/nativeRunner.ts
@@ -26,9 +26,14 @@ export function buildSpawnArgs(opts: {
     inputSocketPath: string;
     tsId?: number;
     outputs: NativeOutput[];
+    /** Output coalescing window in ms (`--flush-ms`). 0 = broadcast every
+     *  splitter batch immediately (ultra-low-latency; per-buffer fan-out
+     *  costs return). Omitted = the runner's built-in 20 ms default. */
+    busBatchMs?: number;
 }): string[] {
     const args = ['--input', opts.inputSocketPath, '--caps', BUS_TS_CAPS];
     if (opts.tsId !== undefined) args.push('--ts-id', String(opts.tsId));
+    if (opts.busBatchMs !== undefined) args.push('--flush-ms', String(opts.busBatchMs));
     for (const o of opts.outputs) {
         const stype = o.streamType !== undefined ? `:0x${o.streamType.toString(16)}` : '';
         args.push('--out', `0x${o.pid.toString(16)}:${busTeeName(o.port)}${stype}`);

--- a/plugins/ts-splitter/native/mr-tssplit/app.cpp
+++ b/plugins/ts-splitter/native/mr-tssplit/app.cpp
@@ -89,14 +89,41 @@ App::App(Options opts) : opts_(std::move(opts)) {
 }
 
 void App::on_input_buffer(const uint8_t* data, size_t len) {
+    // Coalesce before broadcast: splitter batches arrive per input buffer
+    // (~7-packet same-PID runs at typical A/V interleave — measured 692
+    // buffers/s of ~1.3 KB on a 1080p50 feed), and every broadcast costs a
+    // memfd + per-client fd-pass here plus mmap/munmap/close per buffer in
+    // every consumer. Accumulating to BUFFER_BYTES (~24 KB ≈ 22 ms of a
+    // typical video PID) cuts that to ~45/s for at most FLUSH_INTERVAL_MS of
+    // added latency (time flush in flush_due, essential for low-rate PIDs —
+    // audio would take seconds to fill a size batch). Packet order within an
+    // output is preserved; PSI stays ahead of the ES packets it precedes.
+    const int64_t now = mrbus::mono_ns();
     for (const auto& b : core_->feed(data, len)) {
         for (auto& o : outputs_) {
             if (o.pid == b.pid) {
-                o.server->broadcast(b.data->data(), b.data->size());
-                o.batches++;
+                if (o.pending.empty()) o.pending_since_ns = now;
+                o.pending.insert(o.pending.end(), b.data->begin(), b.data->end());
+                if (o.pending.size() >= (size_t)mrbus::BUFFER_BYTES) flush_output(o);
                 break;
             }
         }
+    }
+}
+
+void App::flush_output(Output& o) {
+    if (o.pending.empty()) return;
+    o.server->broadcast(o.pending.data(), o.pending.size());
+    o.batches++;
+    o.pending.clear();
+    o.pending_since_ns = 0;
+}
+
+void App::flush_due(int64_t now_ns) {
+    for (auto& o : outputs_) {
+        if (!o.pending.empty() &&
+            now_ns - o.pending_since_ns >= (int64_t)mrbus::FLUSH_INTERVAL_MS * 1'000'000)
+            flush_output(o);
     }
 }
 
@@ -196,6 +223,11 @@ void App::emit_stats(int64_t now_ns) {
 }
 
 void App::tick(int64_t now_ns) {
+    // Time-based flush for coalesced output (see on_input_buffer). The poll
+    // loop wakes at least every 100 ms idle and per input buffer when
+    // streaming, so flush latency is bounded by FLUSH_INTERVAL_MS in steady
+    // state and by the poll timeout when the source pauses.
+    flush_due(now_ns);
     if (input_) input_->maybe_reconnect(now_ns);
     if (pending_input_) {
         pending_input_->maybe_reconnect(now_ns);

--- a/plugins/ts-splitter/native/mr-tssplit/app.cpp
+++ b/plugins/ts-splitter/native/mr-tssplit/app.cpp
@@ -102,6 +102,12 @@ void App::on_input_buffer(const uint8_t* data, size_t len) {
     for (const auto& b : core_->feed(data, len)) {
         for (auto& o : outputs_) {
             if (o.pid == b.pid) {
+                if (opts_.flush_ns <= 0) {
+                    // Ultra-low-latency mode: no coalescing, no extra copy.
+                    o.server->broadcast(b.data->data(), b.data->size());
+                    o.batches++;
+                    break;
+                }
                 if (o.pending.empty()) o.pending_since_ns = now;
                 o.pending.insert(o.pending.end(), b.data->begin(), b.data->end());
                 if (o.pending.size() >= (size_t)mrbus::BUFFER_BYTES) flush_output(o);
@@ -121,8 +127,7 @@ void App::flush_output(Output& o) {
 
 void App::flush_due(int64_t now_ns) {
     for (auto& o : outputs_) {
-        if (!o.pending.empty() &&
-            now_ns - o.pending_since_ns >= (int64_t)mrbus::FLUSH_INTERVAL_MS * 1'000'000)
+        if (!o.pending.empty() && now_ns - o.pending_since_ns >= opts_.flush_ns)
             flush_output(o);
     }
 }

--- a/plugins/ts-splitter/native/mr-tssplit/app.h
+++ b/plugins/ts-splitter/native/mr-tssplit/app.h
@@ -23,6 +23,12 @@ struct Options {
     std::string caps;
     int ts_id = 1;
     int64_t stall_ns = 2'000'000'000;
+    // Output broadcast coalescing window (--flush-ms). Bounds the latency the
+    // fan-out adds; the BUFFER_BYTES size cap applies independently. 0 =
+    // broadcast every splitter batch immediately (ultra-low-latency mode; the
+    // per-buffer fd-pass/mmap cost returns — measured ~0.35 core across
+    // producer+consumers at 1080p50).
+    int64_t flush_ns = 20'000'000;
     // pid -> tee name (busout_<port>), from --out 0x100:busout_40001
     std::vector<std::pair<int, std::string>> outputs;
     std::vector<int> stream_types;   // parallel to outputs; -1 = unknown
@@ -60,7 +66,8 @@ class App {
         // per-INPUT-buffer runs (~7 pkts / ~1.3 KB at typical interleave), and
         // FanoutServer::broadcast pays a memfd + fd-pass per call — with the
         // consumer paying mmap/munmap/close per buffer. Accumulate here and
-        // flush at BUFFER_BYTES or FLUSH_INTERVAL_MS, whichever first.
+        // flush at BUFFER_BYTES or opts.flush_ns, whichever first
+        // (flush_ns 0 = no coalescing, see Options).
         std::vector<uint8_t> pending;
         int64_t pending_since_ns = 0;
     };

--- a/plugins/ts-splitter/native/mr-tssplit/app.h
+++ b/plugins/ts-splitter/native/mr-tssplit/app.h
@@ -56,9 +56,18 @@ class App {
         std::string tee;
         std::unique_ptr<mrbus::FanoutServer> server;
         long long batches = 0;
+        // Broadcast coalescing (see on_input_buffer): splitter batches are
+        // per-INPUT-buffer runs (~7 pkts / ~1.3 KB at typical interleave), and
+        // FanoutServer::broadcast pays a memfd + fd-pass per call — with the
+        // consumer paying mmap/munmap/close per buffer. Accumulate here and
+        // flush at BUFFER_BYTES or FLUSH_INTERVAL_MS, whichever first.
+        std::vector<uint8_t> pending;
+        int64_t pending_since_ns = 0;
     };
 
     void on_input_buffer(const uint8_t* data, size_t len);
+    void flush_output(Output& o);
+    void flush_due(int64_t now_ns);
     void refresh_gating();
     void emit_stats(int64_t now_ns);
 

--- a/plugins/ts-splitter/native/mr-tssplit/main.cpp
+++ b/plugins/ts-splitter/native/mr-tssplit/main.cpp
@@ -17,7 +17,8 @@
 // output_added/output_add_failed, stats.
 //
 // Usage: mr-tssplit --input <edge socket> --caps <BUS_TS_CAPS> [--ts-id 1]
-//                   [--stall-ms 2000] --out 0x100:busout_40001[:0x1b] ...
+//                   [--stall-ms 2000] [--flush-ms 20]
+//                   --out 0x100:busout_40001[:0x1b] ...
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
@@ -47,6 +48,8 @@ int main(int argc, char** argv) {
             opts.ts_id = std::atoi(argv[++i]);
         } else if (a == "--stall-ms" && i + 1 < argc) {
             opts.stall_ns = (int64_t)std::atoll(argv[++i]) * 1'000'000;
+        } else if (a == "--flush-ms" && i + 1 < argc) {
+            opts.flush_ns = (int64_t)std::atoll(argv[++i]) * 1'000'000;
         } else if (a == "--out" && i + 1 < argc) {
             // pid:tee[:stream_type], e.g. 0x100:busout_40001:0x1b
             std::string spec = argv[++i];
@@ -73,7 +76,7 @@ int main(int argc, char** argv) {
     if (opts.input_socket.empty() || opts.caps.empty()) {
         std::fprintf(stderr,
                      "usage: mr-tssplit --input <socket> --caps <caps> "
-                     "[--ts-id N] [--stall-ms N] --out pid:tee[:stype] ...\n");
+                     "[--ts-id N] [--stall-ms N] [--flush-ms N] --out pid:tee[:stype] ...\n");
         return 2;
     }
 

--- a/plugins/ts-splitter/package.json
+++ b/plugins/ts-splitter/package.json
@@ -17,7 +17,17 @@
         "ports": [],
         "configSchema": {
             "type": "object",
-            "properties": {}
+            "properties": {
+                "busBatchMs": {
+                    "type": "integer",
+                    "title": "Output batching (ms)",
+                    "default": 20,
+                    "minimum": 0,
+                    "maximum": 100,
+                    "x-unit": "ms",
+                    "description": "How long the splitter may coalesce output before sending it on the bus. Batching cuts per-buffer CPU substantially (~0.35 core at 1080p50 across producer and consumers); the value bounds the added latency. Set 0 for ultra-low-latency chains: every parsed batch is forwarded immediately at the original per-buffer cost. Default 20 ms is right for playout and monitoring."
+                }
+            }
         },
         "statusSections": [
             {

--- a/plugins/video-player/engine/VideoPlayerModule.test.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.test.ts
@@ -1348,3 +1348,100 @@ describe('renderWatch health messages', () => {
         expect((module as any).setHealth).toHaveBeenLastCalledWith('ok');
     });
 });
+
+describe('cog restack rule (start-time comparison)', () => {
+    function makeModule() {
+        const module = new VideoPlayerModule() as any;
+        module.log = { info: vi.fn() };
+        module.cogWatchStartedAt = 1000_000;
+        module.currentActiveDisplayName = () => 'HDMI-A-1';
+        module.restartPipeline = vi.fn().mockResolvedValue(undefined);
+        return module;
+    }
+
+    it('cog started after our pipeline → one restack restart, latched per PID', () => {
+        // Field case 2026-08-02 (monitor power-cycle): compositor restart
+        // respawned cog AFTER the video pipeline rebuilt; the old PID-baseline
+        // watch captured the new cog as baseline and never restacked — video
+        // stayed hidden behind the control panel indefinitely.
+        const module = makeModule();
+        const find = () => 500;
+        const start = () => 1000_500; // cog newer than pipeline
+        module.pollCogRestack(find, start);
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1);
+        module.pollCogRestack(find, start); // same cog PID → latched
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1);
+    });
+
+    it('cog well older than our pipeline → no restart (we are already on top)', () => {
+        const module = makeModule();
+        module.pollCogRestack(
+            () => 500,
+            () => 900_000, // 100 s before the watch — far outside the grace window
+        );
+        expect(module.restartPipeline).not.toHaveBeenCalled();
+    });
+
+    it('cog slightly older than our pipeline (surface-grace window) → restack once', () => {
+        // A cog process can predate the pipeline while its page (and thus its
+        // surface) renders after ours — field test 2026-08-02: weston restart
+        // spawned cog ~2 s before the pipeline rebuilt and the exact rule
+        // stayed quiet with the stacking unknown.
+        const module = makeModule();
+        module.pollCogRestack(
+            () => 500,
+            () => 995_000, // 5 s before the watch — inside the 15 s grace
+        );
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1);
+        module.pollCogRestack(() => 500, () => 995_000);
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1); // latched
+    });
+
+    it('the restack latch survives a watch stop/start cycle (no grace-window loop)', () => {
+        const module = makeModule();
+        module.pollCogRestack(() => 500, () => 995_000);
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1);
+        module.stopCogPollWatch();
+        module.cogWatchStartedAt = 1_000_500; // watch re-armed after the rebuild
+        module.pollCogRestack(() => 500, () => 995_000);
+        expect(module.restartPipeline).toHaveBeenCalledTimes(1); // still latched
+    });
+
+    it('cog absent or start time unreadable → wait, no restart', () => {
+        const module = makeModule();
+        module.pollCogRestack(() => undefined, () => 1000_500);
+        module.pollCogRestack(() => 500, () => undefined);
+        expect(module.restartPipeline).not.toHaveBeenCalled();
+    });
+
+    it('a NEW cog incarnation after a latched one restarts again', () => {
+        const module = makeModule();
+        module.pollCogRestack(() => 500, () => 1000_500);
+        module.pollCogRestack(() => 501, () => 1000_900);
+        expect(module.restartPipeline).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('stale renderwatch warning cleared on rebuild', () => {
+    it('onStop clears a lag-owned warning so it cannot outlive the pipeline', async () => {
+        // Field case 2026-08-02: "(0/50 fps)" latched while the compositor
+        // was down; the rebuilt pipeline's fresh monitor starts un-lagged and
+        // only reports transitions, so the warning stuck forever.
+        const module = new VideoPlayerModule() as any;
+        module.setHealth = vi.fn();
+        module.renderLagActive = true;
+        module.health = 'warning';
+        await module.onStop();
+        expect(module.setHealth).toHaveBeenCalledWith('ok');
+        expect(module.renderLagActive).toBe(false);
+    });
+
+    it('onStop leaves health alone when the warning is not lag-owned', async () => {
+        const module = new VideoPlayerModule() as any;
+        module.setHealth = vi.fn();
+        module.renderLagActive = false;
+        module.health = 'warning'; // someone else's warning
+        await module.onStop();
+        expect(module.setHealth).not.toHaveBeenCalledWith('ok');
+    });
+});

--- a/plugins/video-player/engine/VideoPlayerModule.test.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.test.ts
@@ -336,16 +336,29 @@ describe('VideoPlayerModule helpers', () => {
             expect(s).not.toContain('tsparse');
         });
 
-        it('clock-locked mode (preserveSourcePts=true) uses the same tsparse-free input — the source timeline comes from tsdemux PES via preserveSourceTimeline', () => {
+        it('clock-paced sink (sync config) brings tsparse back with re-anchored timestamps', () => {
+            const s = buildLivePipeline(
+                'kmssink name=sink sync=true max-lateness=1000000000 qos=true',
+                busSource,
+                false,
+                200,
+                false,
+                true,
+            );
+            expect(s).toContain('tsparse set-timestamps=true');
+        });
+
+        it('clockSync keeps tsparse but preserves the source timeline (set-timestamps=false)', () => {
             const s = buildLivePipeline(
                 'kmssink name=sink sync=true max-lateness=1000000000 qos=true',
                 busSource,
                 false,
                 200,
                 true,
+                true,
             );
-            expect(s).not.toContain('tsparse');
-            expect(s).toContain('tsdemux');
+            expect(s).toContain('tsparse set-timestamps=false');
+            expect(s).not.toContain('set-timestamps=true');
         });
 
         it('keeps videoscale (uncapped) on the KMS/auto path — no compositor scales for them', () => {

--- a/plugins/video-player/engine/VideoPlayerModule.test.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.test.ts
@@ -327,12 +327,16 @@ describe('VideoPlayerModule helpers', () => {
             expect(s).not.toContain('videotestsrc');
         });
 
-        it('re-anchors PTS by default (tsparse set-timestamps=true) — single-pipeline playout', () => {
+        it('has NO tsparse — the player never re-muxes, and the default sink presents on arrival', () => {
+            // tsparse's job (re-anchoring PCR so multi-stage remux chains don't
+            // drift) doesn't apply to a terminal display pipeline, and it was
+            // the chain's single most expensive element (0.11 core at 1080p50,
+            // measured 2026-08-01). tsdemux consumes the bus buffers directly.
             const s = buildLivePipeline('kmssink name=sink sync=false qos=true', busSource);
-            expect(s).toContain('tsparse set-timestamps=true');
+            expect(s).not.toContain('tsparse');
         });
 
-        it('preserves source PTS when clock-locked (preserveSourcePts=true) so it shares the audio timeline', () => {
+        it('clock-locked mode (preserveSourcePts=true) uses the same tsparse-free input — the source timeline comes from tsdemux PES via preserveSourceTimeline', () => {
             const s = buildLivePipeline(
                 'kmssink name=sink sync=true max-lateness=1000000000 qos=true',
                 busSource,
@@ -340,8 +344,8 @@ describe('VideoPlayerModule helpers', () => {
                 200,
                 true,
             );
-            expect(s).toContain('tsparse set-timestamps=false');
-            expect(s).not.toContain('set-timestamps=true');
+            expect(s).not.toContain('tsparse');
+            expect(s).toContain('tsdemux');
         });
 
         it('keeps videoscale (uncapped) on the KMS/auto path — no compositor scales for them', () => {
@@ -428,15 +432,13 @@ describe('VideoPlayerModule helpers', () => {
             expect(s).toContain('watchdog name=buswd_5000 timeout=5000');
         });
 
-        it('orders unixfdsrc → watchdog → tsparse → tsdemux (watchdog sees raw socket delivery)', () => {
+        it('orders unixfdsrc → watchdog → tsdemux (watchdog sees raw socket delivery)', () => {
             const s = buildLivePipeline('kmssink name=sink sync=false qos=true', busSource);
             const idxSrc = s.indexOf('unixfdsrc');
             const idxWd = s.indexOf('watchdog');
-            const idxTsparse = s.indexOf('tsparse');
             const idxTsdemux = s.indexOf('tsdemux');
             expect(idxSrc).toBeLessThan(idxWd);
-            expect(idxWd).toBeLessThan(idxTsparse);
-            expect(idxTsparse).toBeLessThan(idxTsdemux);
+            expect(idxWd).toBeLessThan(idxTsdemux);
         });
     });
 

--- a/plugins/video-player/engine/VideoPlayerModule.test.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.test.ts
@@ -1215,3 +1215,61 @@ describe('VideoPlayerModule helpers', () => {
         });
     });
 });
+
+describe('renderWatch health messages', () => {
+    function makeModule() {
+        const module = new VideoPlayerModule();
+        (module as any).setHealth = vi.fn();
+        return module;
+    }
+
+    it('render lag (presented below arrivals) → lower-resolution advice', () => {
+        const module = makeModule();
+        (module as any).onPluginEvent('renderwatch:lag', {
+            achievedFps: 41,
+            expectedFps: 50,
+            arrivalsFps: 50,
+        });
+        expect((module as any).setHealth).toHaveBeenCalledWith(
+            'warning',
+            "Video output can't keep up (41/50 fps) — lower the stream or display resolution",
+        );
+    });
+
+    it('source shortfall (presented ≈ arrivals) → check-the-link advice, not resolution advice', () => {
+        // Field case 2026-08-01: RIST link dips deliver only ~41 fps; the sink
+        // presents every frame that arrives (dropped=0). Blaming the render
+        // chain would send the operator to the wrong knob.
+        const module = makeModule();
+        (module as any).onPluginEvent('renderwatch:lag', {
+            achievedFps: 41,
+            expectedFps: 50,
+            arrivalsFps: 41.5,
+        });
+        expect((module as any).setHealth).toHaveBeenCalledWith(
+            'warning',
+            'Stream under-delivering (41/50 fps) — check the source/link (display is keeping up)',
+        );
+    });
+
+    it('missing arrivalsFps (older runner) falls back to the render-lag message', () => {
+        const module = makeModule();
+        (module as any).onPluginEvent('renderwatch:lag', { achievedFps: 41, expectedFps: 50 });
+        expect((module as any).setHealth).toHaveBeenCalledWith(
+            'warning',
+            expect.stringContaining("can't keep up"),
+        );
+    });
+
+    it('recovered clears only a warning this module raised', () => {
+        const module = makeModule();
+        (module as any).onPluginEvent('renderwatch:lag', {
+            achievedFps: 41,
+            expectedFps: 50,
+            arrivalsFps: 50,
+        });
+        (module as any).health = 'warning';
+        (module as any).onPluginEvent('renderwatch:recovered', {});
+        expect((module as any).setHealth).toHaveBeenLastCalledWith('ok');
+    });
+});

--- a/plugins/video-player/engine/VideoPlayerModule.test.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.test.ts
@@ -1048,12 +1048,44 @@ describe('VideoPlayerModule helpers', () => {
                 await (module as any).pollBusResume();
                 expect(restart).not.toHaveBeenCalled();
 
-                // Counter advanced: source resumed → back to live.
+                // Counter advancing — but resume waits for a STABLE streak
+                // (RESUME_STABLE_POLLS consecutive flowing polls) so the live
+                // pipeline doesn't rebuild against a still-churning source.
                 readBytes.mockResolvedValue(2000);
+                await (module as any).pollBusResume();
+                expect(restart).not.toHaveBeenCalled();
+                readBytes.mockResolvedValue(3000);
+                await (module as any).pollBusResume();
+                expect(restart).not.toHaveBeenCalled();
+                readBytes.mockResolvedValue(4000);
                 await (module as any).pollBusResume();
                 expect((module as any).busStallDetected).toBe(false);
                 expect(restart).toHaveBeenCalledTimes(1);
                 expect((module as any).busResumeWatchdog).toBeNull();
+            });
+
+            it('a flat poll mid-streak resets the stability gate', async () => {
+                const module = makeModule();
+                (module as any).busStallDetected = true;
+                (module as any).resumeTapActive = true;
+                const restart = vi
+                    .spyOn(module as any, 'restartPipeline')
+                    .mockResolvedValue(undefined);
+                const readBytes = vi
+                    .spyOn(module as any, 'readBusSinkBytes')
+                    .mockResolvedValue(1000);
+                await (module as any).pollBusResume(); // baseline
+                readBytes.mockResolvedValue(2000);
+                await (module as any).pollBusResume(); // streak 1
+                readBytes.mockResolvedValue(3000);
+                await (module as any).pollBusResume(); // streak 2
+                await (module as any).pollBusResume(); // flat → streak 0
+                readBytes.mockResolvedValue(4000);
+                await (module as any).pollBusResume(); // streak 1
+                readBytes.mockResolvedValue(5000);
+                await (module as any).pollBusResume(); // streak 2
+                expect(restart).not.toHaveBeenCalled();
+                expect((module as any).busStallDetected).toBe(true);
             });
 
             it('does nothing while a restart cycle is already in flight', async () => {
@@ -1082,8 +1114,12 @@ describe('VideoPlayerModule helpers', () => {
                 expect(restart).not.toHaveBeenCalled();
                 expect((module as any).busStallDetected).toBe(true);
 
-                // Producer respawned — socket answers → retry live directly.
+                // Producer respawned — socket answers on 3 consecutive
+                // polls (the stability gate) → retry live directly.
                 probeUnixSocketMock.mockResolvedValue(true);
+                await (module as any).pollBusResume();
+                await (module as any).pollBusResume();
+                expect(restart).not.toHaveBeenCalled();
                 await (module as any).pollBusResume();
                 expect((module as any).busStallDetected).toBe(false);
                 expect(restart).toHaveBeenCalledTimes(1);
@@ -1259,6 +1295,45 @@ describe('renderWatch health messages', () => {
             'warning',
             expect.stringContaining("can't keep up"),
         );
+    });
+
+    it('render lag shortly after a stall-resume triggers ONE self-heal rebuild', () => {
+        // Field case 2026-08-02: live pipeline rebuilt against a just-recovered,
+        // still-churning source ran degraded (green band + steady late-drops)
+        // until a manual restart. One free rebuild per resume fixes that; a
+        // second lag is a real render problem and stays visible.
+        const module = makeModule();
+        const restart = vi.spyOn(module as any, 'restartPipeline').mockResolvedValue(undefined);
+        (module as any).log = { info: vi.fn() };
+        (module as any).lastStallResumeAt = Date.now() - 10_000;
+        const lag = { achievedFps: 44, expectedFps: 50, arrivalsFps: 49 };
+        (module as any).onPluginEvent('renderwatch:lag', lag);
+        expect(restart).toHaveBeenCalledTimes(1);
+        (module as any).onPluginEvent('renderwatch:lag', lag);
+        expect(restart).toHaveBeenCalledTimes(1);
+    });
+
+    it('no self-heal outside the post-resume window or for source shortfall', () => {
+        const module = makeModule();
+        const restart = vi.spyOn(module as any, 'restartPipeline').mockResolvedValue(undefined);
+        (module as any).log = { info: vi.fn() };
+        // Old resume: outside the heal window.
+        (module as any).lastStallResumeAt = Date.now() - 600_000;
+        (module as any).onPluginEvent('renderwatch:lag', {
+            achievedFps: 44,
+            expectedFps: 50,
+            arrivalsFps: 49,
+        });
+        expect(restart).not.toHaveBeenCalled();
+        // Recent resume but the SOURCE is under-delivering — a rebuild can't
+        // manufacture frames the stream never carried.
+        (module as any).lastStallResumeAt = Date.now() - 10_000;
+        (module as any).onPluginEvent('renderwatch:lag', {
+            achievedFps: 41,
+            expectedFps: 50,
+            arrivalsFps: 41,
+        });
+        expect(restart).not.toHaveBeenCalled();
     });
 
     it('recovered clears only a warning this module raised', () => {

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -175,9 +175,48 @@ export class VideoPlayerModule extends GstPluginBase {
         this.startCogPollWatch();
     }
 
+    /**
+     * Latched while the runner's renderWatch reports the pipeline lagging
+     * behind the stream's declared framerate. Owns the corresponding health
+     * warning: recovery only clears health that this latch set.
+     */
+    private renderLagActive = false;
+
+    /**
+     * Render keep-up events from the runner's `renderWatch` (see
+     * PipelineDescription.renderWatch). Lag means frames are being shed by
+     * the leaky queues — the decode/convert/render chain cannot sustain the
+     * source rate. Nothing here can fix that, so tell the operator what to
+     * change.
+     */
+    protected onPluginEvent(channel: string, payload: unknown): void {
+        if (channel === 'renderwatch:lag') {
+            const p = (payload ?? {}) as { achievedFps?: number; expectedFps?: number };
+            this.renderLagActive = true;
+            const rate =
+                typeof p.achievedFps === 'number' && typeof p.expectedFps === 'number'
+                    ? ` (${p.achievedFps}/${p.expectedFps} fps)`
+                    : '';
+            this.setHealth(
+                'warning',
+                `Video output can't keep up${rate} — lower the stream or display resolution`,
+            );
+        } else if (channel === 'renderwatch:recovered') {
+            // Only clear health WE degraded — never stomp a bus-stall or
+            // substituted-display warning someone else owns.
+            if (this.renderLagActive && this.health === 'warning') {
+                this.setHealth('ok');
+            }
+            this.renderLagActive = false;
+        }
+    }
+
     async onStop(): Promise<void> {
         this.stopCogPollWatch();
         this.stopBusResumeWatchdog();
+        // A rebuilt pipeline gets a fresh runner-side monitor that re-measures
+        // from scratch — a stale lag latch must not suppress or fake events.
+        this.renderLagActive = false;
         // During an *internal* restart cycle (latched by pipelineRestartInProgress)
         // we deliberately keep the bus-stall latch alive so the rebuilt
         // pipeline picks the fallback path that triggered this very restart
@@ -333,7 +372,14 @@ export class VideoPlayerModule extends GstPluginBase {
 
     private currentActiveDisplayName(): string {
         const requested = (this.config?.display as string) ?? '';
-        return pickActiveDisplay(requested).name;
+        // Same fallback as the surface/app_id resolution in buildPipeline:
+        // with no display configured, `pickActiveDisplay('')` returns an
+        // empty name — which silently disabled the cog poll watch
+        // (`findCogPidForDisplay('')` matches nothing), so a cog respawn
+        // after a weston restart could land ON TOP of the video and starve
+        // its frame callbacks to ~1 fps while decode kept burning CPU,
+        // with no recovery. Observed on a Pi 4 field device, 2026-08-01.
+        return pickActiveDisplay(requested).name || firstConnectedDisplay() || '';
     }
 
 
@@ -576,7 +622,16 @@ export class VideoPlayerModule extends GstPluginBase {
             // more buffering latency). Live-updatable via the named `sink`.
             tsOffsetNs: Math.round(Number(this.config.lipSyncMs ?? 0) * 1_000_000),
         });
-        const env = buildPipelineEnv(active.name, sinkEnv);
+        // `active.name` is empty when the user hasn't picked a display
+        // (`pickActiveDisplay('')` returns an empty name by design), which left
+        // the surface with NO `MR_GLIB_PRGNAME` app_id. kiosk-shell only maps
+        // surfaces whose app_id is listed in that output's `app-ids=`, so an
+        // unpinned surface is never placed and the video is simply absent —
+        // exactly the "output that isn't lit" failure the comment above warns
+        // about. Fall back to the first lit physical output, the same fallback
+        // `surfaceConnector` already uses below, so an unconfigured module
+        // renders instead of silently going nowhere.
+        const env = buildPipelineEnv(active.name || firstConnectedDisplay() || '', sinkEnv);
         // On the wayland (kiosk-shell fullscreen) path the compositor scales
         // our surface onto the output itself, so the live pipeline must not
         // scale in software. KMS / autovideosink have no compositor and keep
@@ -661,6 +716,10 @@ export class VideoPlayerModule extends GstPluginBase {
             restartOnError: true,
             env,
             decoderThreadType: resolveDecoderThreadType(this.config.cpuDecodeThreading),
+            // Keep-up watch on the live render chain (see onPluginEvent).
+            // Only the wayland/kms sinks are named — autovideosink (dev) is a
+            // bin without `name=sink`, so the runner would fail the lookup.
+            ...(sinkElement.includes('name=sink') ? { renderWatch: { sink: 'sink' } } : {}),
             ...(clockSync ? { clockSync: true } : {}),
         };
     }

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -712,6 +712,9 @@ export class VideoPlayerModule extends GstPluginBase {
                 waylandFullscreen,
                 Number(this.config.bufferMs ?? 200),
                 clockSync,
+                // Clock-paced sink (sync config or clockSync) → tsparse
+                // returns to the chain for clock-anchored timestamps.
+                clockSync || ((this.config.sync as boolean | undefined) ?? false),
             ),
             restartOnError: true,
             env,

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -191,15 +191,32 @@ export class VideoPlayerModule extends GstPluginBase {
      */
     protected onPluginEvent(channel: string, payload: unknown): void {
         if (channel === 'renderwatch:lag') {
-            const p = (payload ?? {}) as { achievedFps?: number; expectedFps?: number };
+            const p = (payload ?? {}) as {
+                achievedFps?: number;
+                expectedFps?: number;
+                arrivalsFps?: number;
+            };
             this.renderLagActive = true;
             const rate =
                 typeof p.achievedFps === 'number' && typeof p.expectedFps === 'number'
                     ? ` (${p.achievedFps}/${p.expectedFps} fps)`
                     : '';
+            // Attribute the shortfall correctly: when the sink presents
+            // essentially everything that ARRIVES, the render chain isn't the
+            // problem — the source is delivering fewer frames (link jitter,
+            // encoder hiccup). Telling the operator to lower the resolution
+            // for that would be wrong advice. Field case, 2026-08-01: OCC
+            // link dips to ~41 fps for a few seconds; arrivals == presented,
+            // drops == 0.
+            const sourceShortfall =
+                typeof p.achievedFps === 'number' &&
+                typeof p.arrivalsFps === 'number' &&
+                p.achievedFps >= p.arrivalsFps - 1;
             this.setHealth(
                 'warning',
-                `Video output can't keep up${rate} — lower the stream or display resolution`,
+                sourceShortfall
+                    ? `Stream under-delivering${rate} — check the source/link (display is keeping up)`
+                    : `Video output can't keep up${rate} — lower the stream or display resolution`,
             );
         } else if (channel === 'renderwatch:recovered') {
             // Only clear health WE degraded — never stomp a bus-stall or

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -617,7 +617,7 @@ export class VideoPlayerModule extends GstPluginBase {
         const clockSync = (this.config.clockSync as boolean | undefined) === true;
         const sinkElement = buildSink(active.name, sinkEnv, {
             qos: (this.config.qos as boolean | undefined) ?? true,
-            sync: clockSync || ((this.config.sync as boolean | undefined) ?? false),
+            sync: clockSync || ((this.config.sync as boolean | undefined) ?? true),
             // Positive lipSyncMs delays video to meet late audio (audio path has
             // more buffering latency). Live-updatable via the named `sink`.
             tsOffsetNs: Math.round(Number(this.config.lipSyncMs ?? 0) * 1_000_000),
@@ -714,7 +714,7 @@ export class VideoPlayerModule extends GstPluginBase {
                 clockSync,
                 // Clock-paced sink (sync config or clockSync) → tsparse
                 // returns to the chain for clock-anchored timestamps.
-                clockSync || ((this.config.sync as boolean | undefined) ?? false),
+                clockSync || ((this.config.sync as boolean | undefined) ?? true),
             ),
             restartOnError: true,
             env,

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -36,6 +36,11 @@ import { resolveWestonSurface } from './helpers/westonOutput.js';
 
 type SinkAvailability = { wayland: boolean; kms: boolean };
 
+/** Consecutive flowing 1 Hz polls required before a stall-resume rebuild. */
+const RESUME_STABLE_POLLS = 3;
+/** How long after a stall-resume a renderwatch lag earns a free rebuild. */
+const POST_RESUME_HEAL_WINDOW_MS = 120_000;
+
 /**
  * Video Player plugin.
  *
@@ -110,6 +115,20 @@ export class VideoPlayerModule extends GstPluginBase {
     private resumeTapActive = false;
     /** Last byte count read off the resume tap — advance = source resumed. */
     private lastResumeBytes: number | undefined;
+    /**
+     * Consecutive 1 Hz polls that saw the source flowing. Resuming on the
+     * FIRST sign of bytes rebuilt the live pipeline against a still-churning
+     * source (field case 2026-08-02: upstream restart chain — tsparse latched
+     * a skewed timing baseline and the pipeline ran degraded for minutes:
+     * green slice corruption, ~10 % late-drops). Requiring a short streak
+     * costs RESUME_STABLE_POLLS-1 extra seconds of fallback and rebuilds
+     * against a stream that has actually settled.
+     */
+    private resumeStreak = 0;
+    /** When the last stall-resume rebuilt the live pipeline (0 = never). */
+    private lastStallResumeAt = 0;
+    /** One free self-heal rebuild per resume — see onPluginEvent. */
+    private postResumeHealDone = false;
     /**
      * 1 Hz resume poller, alive while we're latched in fallback. With the
      * tap active it reads the tap's byte counter (bytes advancing = source
@@ -218,6 +237,24 @@ export class VideoPlayerModule extends GstPluginBase {
                     ? `Stream under-delivering${rate} — check the source/link (display is keeping up)`
                     : `Video output can't keep up${rate} — lower the stream or display resolution`,
             );
+            // Self-heal: lag right after a stall-resume means the live
+            // pipeline rebuilt against a source that had not fully settled
+            // (field case 2026-08-02: skewed timing baseline → green slice
+            // corruption + steady late-drops until a MANUAL restart). One
+            // free rebuild per resume; a rebuild that lags again is a real
+            // render problem and stays for the operator to see.
+            if (
+                !sourceShortfall &&
+                !this.postResumeHealDone &&
+                this.lastStallResumeAt > 0 &&
+                Date.now() - this.lastStallResumeAt < POST_RESUME_HEAL_WINDOW_MS
+            ) {
+                this.postResumeHealDone = true;
+                this.log.info('Render lag shortly after stall-resume — rebuilding pipeline once');
+                this.restartPipeline().catch(() => {
+                    /* logged inside */
+                });
+            }
         } else if (channel === 'renderwatch:recovered') {
             // Only clear health WE degraded — never stomp a bus-stall or
             // substituted-display warning someone else owns.
@@ -290,7 +327,7 @@ export class VideoPlayerModule extends GstPluginBase {
         const instanceId = this.services?.instanceId ?? '';
         const source = this.services?.mediaRouter?.getModuleBusSource(instanceId);
         if (!source) return;
-        let resumed = false;
+        let flowing = false;
         if (this.resumeTapActive) {
             const bytes = await this.readBusSinkBytes(RESUME_SINK_NAME);
             if (
@@ -298,15 +335,18 @@ export class VideoPlayerModule extends GstPluginBase {
                 this.lastResumeBytes !== undefined &&
                 bytes > this.lastResumeBytes
             ) {
-                resumed = true;
+                flowing = true;
             }
             if (bytes !== undefined) this.lastResumeBytes = bytes;
         } else if (source.socketPath && (await probeUnixSocket(source.socketPath))) {
-            resumed = true;
+            flowing = true;
         }
-        if (!resumed || !this.busStallDetected) return;
+        this.resumeStreak = flowing ? this.resumeStreak + 1 : 0;
+        if (this.resumeStreak < RESUME_STABLE_POLLS || !this.busStallDetected) return;
         this.log.info('Source resumed — restarting live pipeline');
         this.busStallDetected = false;
+        this.lastStallResumeAt = Date.now();
+        this.postResumeHealDone = false;
         this.stopBusResumeWatchdog();
         this.restartPipeline().catch(() => {
             /* logged inside */
@@ -316,6 +356,7 @@ export class VideoPlayerModule extends GstPluginBase {
     private startBusResumeWatchdog(): void {
         if (this.busResumeWatchdog) return;
         this.lastResumeBytes = undefined;
+        this.resumeStreak = 0;
         // 1 Hz is plenty — worst case is one extra second of fallback.
         // Lifetime is bounded to "we're latched in fallback": armed by the
         // bus_stall listener (and re-armed by installBusStallListener after
@@ -333,6 +374,7 @@ export class VideoPlayerModule extends GstPluginBase {
             this.busResumeWatchdog = null;
         }
         this.lastResumeBytes = undefined;
+        this.resumeStreak = 0;
     }
 
     /** Wipe stall state on an external stop — fresh start should never inherit a stale fallback decision. */
@@ -340,6 +382,8 @@ export class VideoPlayerModule extends GstPluginBase {
         this.stopBusResumeWatchdog();
         this.busStallDetected = false;
         this.resumeTapActive = false;
+        this.lastStallResumeAt = 0;
+        this.postResumeHealDone = false;
     }
 
     /**

--- a/plugins/video-player/engine/VideoPlayerModule.ts
+++ b/plugins/video-player/engine/VideoPlayerModule.ts
@@ -19,6 +19,7 @@ import {
     ensureWaylandEnv,
     findCogPidForDisplay,
     hasWaylandSession,
+    processStartMs,
     waitForWaylandSocket,
 } from './helpers/wayland.js';
 import {
@@ -38,6 +39,15 @@ type SinkAvailability = { wayland: boolean; kms: boolean };
 
 /** Consecutive flowing 1 Hz polls required before a stall-resume rebuild. */
 const RESUME_STABLE_POLLS = 3;
+/**
+ * A cog PROCESS can predate our pipeline while its SURFACE (mapped when the
+ * page first renders, seconds after spawn) still lands on top of ours. Treat
+ * any cog started within this window before our watch began as potentially
+ * newer-surfaced and restack once. Cost when wrong: one extra ~2 s pipeline
+ * blip after a compositor restart; cost of the old exact rule when wrong:
+ * video invisible until a human intervenes.
+ */
+const COG_SURFACE_GRACE_MS = 15_000;
 /** How long after a stall-resume a renderwatch lag earns a free rebuild. */
 const POST_RESUME_HEAL_WINDOW_MS = 120_000;
 
@@ -97,7 +107,10 @@ export class VideoPlayerModule extends GstPluginBase {
     // pinned to our active display changes, kick a pipeline restart so
     // our surface becomes the newest one and lands back on top.
     private cogPollTimer: NodeJS.Timeout | null = null;
-    private lastCogPid: number | undefined = undefined;
+    /** When this pipeline's cog watch (≈ surface creation) began. */
+    private cogWatchStartedAt = 0;
+    /** Cog PID we already restacked for — one restart per cog incarnation. */
+    private lastRestackCogPid: number | undefined = undefined;
 
     // Source-silent fallback. When the live pipeline's stall watchdog fires
     // (no buffer off the bus socket for 5 s) the Python runner tags the
@@ -270,6 +283,14 @@ export class VideoPlayerModule extends GstPluginBase {
         this.stopBusResumeWatchdog();
         // A rebuilt pipeline gets a fresh runner-side monitor that re-measures
         // from scratch — a stale lag latch must not suppress or fake events.
+        // Clear the warning the latch owns too: the fresh monitor starts
+        // un-lagged and only reports TRANSITIONS, so it would never emit the
+        // "recovered" that clears it (field 2026-08-02: "can't keep up
+        // (0/50 fps)" stuck on a healthy pipeline after a compositor-restart
+        // rebuild).
+        if (this.renderLagActive && this.health === 'warning') {
+            this.setHealth('ok');
+        }
         this.renderLagActive = false;
         // During an *internal* restart cycle (latched by pipelineRestartInProgress)
         // we deliberately keep the bus-stall latch alive so the rebuilt
@@ -398,29 +419,42 @@ export class VideoPlayerModule extends GstPluginBase {
     private startCogPollWatch(): void {
         if (this.cogPollTimer) return;
         if (!VideoPlayerModule.sinks.wayland || !hasWaylandSession()) return;
-        const display = this.currentActiveDisplayName();
-        if (!display) return;
-        this.lastCogPid = findCogPidForDisplay(display);
-        this.cogPollTimer = setInterval(() => {
-            const activeDisplay = this.currentActiveDisplayName();
-            if (!activeDisplay) return;
-            const current = findCogPidForDisplay(activeDisplay);
-            if (current === undefined) return; // cog mid-restart, wait
-            if (this.lastCogPid === undefined) {
-                this.lastCogPid = current;
-                return;
-            }
-            if (current === this.lastCogPid) return;
-            const previous = this.lastCogPid;
-            this.lastCogPid = current;
-            this.log.info(
-                { display: activeDisplay, previousPid: previous, newPid: current },
-                'Kiosk browser respawned on our output — restarting video pipeline',
-            );
-            this.restartPipeline().catch(() => {
-                /* logged inside */
-            });
-        }, COG_POLL_INTERVAL_MS);
+        if (!this.currentActiveDisplayName()) return;
+        this.cogWatchStartedAt = Date.now();
+        this.cogPollTimer = setInterval(() => this.pollCogRestack(), COG_POLL_INTERVAL_MS);
+    }
+
+    /**
+     * Restack rule: kiosk-shell stacks newest surface on top, so a cog whose
+     * PROCESS started after this pipeline did will cover the video once its
+     * page renders. A PID-change baseline missed the compositor-restart case
+     * (field 2026-08-02, monitor power-cycle): the video pipeline and cog
+     * respawn together, the baseline was captured AFTER the new cog spawned,
+     * and the video stayed hidden behind the control panel with the pipeline
+     * happily presenting to an occluded surface. Comparing process start
+     * times has no baseline to race: cog newer than us → restart once (latched
+     * per PID; the rebuilt pipeline is then newest and the rule goes quiet).
+     */
+    private pollCogRestack(
+        findPid: typeof findCogPidForDisplay = findCogPidForDisplay,
+        startMs: typeof processStartMs = processStartMs,
+    ): void {
+        const activeDisplay = this.currentActiveDisplayName();
+        if (!activeDisplay) return;
+        const current = findPid(activeDisplay);
+        if (current === undefined) return; // cog mid-restart, wait
+        if (current === this.lastRestackCogPid) return;
+        const cogStart = startMs(current);
+        if (cogStart === undefined) return;
+        if (cogStart <= this.cogWatchStartedAt - COG_SURFACE_GRACE_MS) return;
+        this.lastRestackCogPid = current;
+        this.log.info(
+            { display: activeDisplay, cogPid: current },
+            'Kiosk browser surfaced after our pipeline — restarting video pipeline to restack',
+        );
+        this.restartPipeline().catch(() => {
+            /* logged inside */
+        });
     }
 
     private stopCogPollWatch(): void {
@@ -428,7 +462,10 @@ export class VideoPlayerModule extends GstPluginBase {
             clearInterval(this.cogPollTimer);
             this.cogPollTimer = null;
         }
-        this.lastCogPid = undefined;
+        // `lastRestackCogPid` deliberately survives: the grace window means a
+        // freshly-restacked pipeline would otherwise see the SAME cog inside
+        // the window again after its own restart and loop. One restack per
+        // cog incarnation, per module instance.
     }
 
     private currentActiveDisplayName(): string {

--- a/plugins/video-player/engine/helpers/pipelines.ts
+++ b/plugins/video-player/engine/helpers/pipelines.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { buildTsUdpInput } from '@media-router/engine';
+import { buildBusSrc, buildLeakyQueue } from '@media-router/engine';
 
 /**
  * Surface size used when the output's own mode can't be resolved (headless,
@@ -264,10 +264,9 @@ export function buildFallbackOnlyPipeline(
  * A DEAD producer needs no watchdog — its edge socket closes and unixfdsrc
  * errors out into the normal restart path.
  *
- * Inbound chain is `unixfdsrc ! queue ! tsparse ! tsdemux` (via
- * `buildTsUdpInput`) — `tsparse` re-anchors PCR to the local clock so
- * multi-stage encode/remux paths don't accumulate clock drift as session
- * latency. `decodebin` handles any codec inside the MPEG-TS; the post-tsdemux
+ * Inbound chain is `unixfdsrc ! watchdog ! queue ! queue ! tsdemux` —
+ * deliberately WITHOUT `tsparse` (see the comment at the construction site
+ * below). `decodebin` handles any codec inside the MPEG-TS; the post-tsdemux
  * `queue leaky=2` drops oldest if the decoder falls behind so latency doesn't
  * accumulate on slow renderers.
  */
@@ -305,15 +304,25 @@ export function buildLivePipeline(
     // at every segment join. Tracking `bufferMs` (up to `buildLeakyQueue`'s 5 s
     // cap) gives HLS chains a multi-second jitter buffer that absorbs sender
     // bursts; SRT/RIST (`bufferMs=200`) keeps the original tight latency.
-    const tsInput = buildTsUdpInput({
+    // NO `tsparse` in the player's inbound chain (deliberate divergence from
+    // `buildTsUdpInput`, measured on a field Pi 4, 2026-08-01):
+    //  - tsparse's documented job — re-anchoring PCR so multi-stage RE-MUX
+    //    paths don't accumulate clock drift — doesn't apply here: this
+    //    pipeline terminates at a display sink and never re-muxes.
+    //  - The default sink runs `sync=false` (presents on arrival), so
+    //    pipeline timestamps are unused; with `clockSync`, timing comes from
+    //    the PES timeline via `preserveSourceTimeline` on tsdemux, which
+    //    tsparse also doesn't participate in.
+    //  - The leaky jitter queue sits UPSTREAM of where tsparse sat and
+    //    operates on the bus producer's timestamps either way.
+    //  - Cost: `tsparse set-timestamps=true` measured 0.11 core at 1080p50
+    //    (it re-frames per TS packet), the single most expensive element in
+    //    the chain; tsdemux consumes the raw bus buffers directly at +0.06.
+    const tsInput = `${buildBusSrc({
         port: udpSource.port,
         socketPath: udpSource.socketPath,
         stallTimeoutMs: STREAM_STALL_TIMEOUT_MS,
-        jitterMs: bufferMs,
-        // Keep source PTS when clock-locked to the audio pipeline; re-anchor
-        // otherwise (the load-bearing default for standalone playout).
-        setTimestamps: !preserveSourcePts,
-    });
+    })} ! ${buildLeakyQueue(bufferMs)}`;
     const q = `queue leaky=2 max-size-time=${bufferMs * 1_000_000} max-size-buffers=0 max-size-bytes=0`;
     // Scaling policy — who resizes the picture, per sink:
     //

--- a/plugins/video-player/engine/helpers/pipelines.ts
+++ b/plugins/video-player/engine/helpers/pipelines.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { buildBusSrc, buildLeakyQueue } from '@media-router/engine';
+import { buildBusSrc, buildLeakyQueue, buildTsUdpInput } from '@media-router/engine';
 
 /**
  * Surface size used when the output's own mode can't be resolved (headless,
@@ -264,11 +264,12 @@ export function buildFallbackOnlyPipeline(
  * A DEAD producer needs no watchdog — its edge socket closes and unixfdsrc
  * errors out into the normal restart path.
  *
- * Inbound chain is `unixfdsrc ! watchdog ! queue ! queue ! tsdemux` —
- * deliberately WITHOUT `tsparse` (see the comment at the construction site
- * below). `decodebin` handles any codec inside the MPEG-TS; the post-tsdemux
- * `queue leaky=2` drops oldest if the decoder falls behind so latency doesn't
- * accumulate on slow renderers.
+ * Inbound chain is `unixfdsrc ! watchdog ! queue ! queue ! tsdemux` by
+ * default — WITHOUT `tsparse` — and gains `tsparse` back when the sink is
+ * clock-paced (see the comment at the construction site below). `decodebin`
+ * handles any codec inside the MPEG-TS; the post-tsdemux `queue leaky=2`
+ * drops oldest if the decoder falls behind so latency doesn't accumulate on
+ * slow renderers.
  */
 const STREAM_STALL_TIMEOUT_MS = 5_000;
 
@@ -296,6 +297,14 @@ export function buildLivePipeline(
      * behaviour. The caller pairs this with a `sync=true` sink + `clockSync`.
      */
     preserveSourcePts = false,
+    /**
+     * True when the sink honours buffer PTS (`sync=true` — the module's `sync`
+     * config or `clockSync`). A clock-paced sink needs clock-anchored
+     * timestamps, which is `tsparse`'s job — so pacing brings tsparse back
+     * into the chain (see the tsInput comment below). Default false = the
+     * tsparse-free present-on-arrival fast path.
+     */
+    sinkPaced = false,
 ): string {
     // Pre-tsparse jitter buffer scales with `bufferMs`: with a paced sender on
     // a busy Node loop (hls-pipe runner transmuxing the next segment), the
@@ -304,25 +313,37 @@ export function buildLivePipeline(
     // at every segment join. Tracking `bufferMs` (up to `buildLeakyQueue`'s 5 s
     // cap) gives HLS chains a multi-second jitter buffer that absorbs sender
     // bursts; SRT/RIST (`bufferMs=200`) keeps the original tight latency.
-    // NO `tsparse` in the player's inbound chain (deliberate divergence from
-    // `buildTsUdpInput`, measured on a field Pi 4, 2026-08-01):
-    //  - tsparse's documented job — re-anchoring PCR so multi-stage RE-MUX
-    //    paths don't accumulate clock drift — doesn't apply here: this
-    //    pipeline terminates at a display sink and never re-muxes.
-    //  - The default sink runs `sync=false` (presents on arrival), so
-    //    pipeline timestamps are unused; with `clockSync`, timing comes from
-    //    the PES timeline via `preserveSourceTimeline` on tsdemux, which
-    //    tsparse also doesn't participate in.
-    //  - The leaky jitter queue sits UPSTREAM of where tsparse sat and
-    //    operates on the bus producer's timestamps either way.
-    //  - Cost: `tsparse set-timestamps=true` measured 0.11 core at 1080p50
-    //    (it re-frames per TS packet), the single most expensive element in
-    //    the chain; tsdemux consumes the raw bus buffers directly at +0.06.
-    const tsInput = `${buildBusSrc({
-        port: udpSource.port,
-        socketPath: udpSource.socketPath,
-        stallTimeoutMs: STREAM_STALL_TIMEOUT_MS,
-    })} ! ${buildLeakyQueue(bufferMs)}`;
+    // The inbound chain has two variants, chosen by how the SINK presents:
+    //
+    // DEFAULT (`sync=false`, presents on arrival): NO `tsparse` (field-
+    // measured on a Pi 4, 2026-08-01). Its documented job — re-anchoring PCR
+    // so multi-stage RE-MUX paths don't drift — doesn't apply to a terminal
+    // display pipeline, timestamps go unused by a non-syncing sink, the leaky
+    // jitter queue sits upstream of where tsparse sat anyway, and it was the
+    // chain's single most expensive element (0.11 core at 1080p50; tsdemux
+    // eats the raw bus buffers directly at +0.06).
+    //
+    // CLOCK-PACED (`sinkPaced` — the `sync` config or `clockSync`): tsparse
+    // RETURNS with `set-timestamps=<!preserveSourcePts>`. A sync=true sink
+    // presents each frame at its PTS against the pipeline clock, which is
+    // only meaningful with clock-anchored timestamps — exactly what
+    // `tsparse set-timestamps=true` produces (PCR-derived, smoothed, local-
+    // clock-anchored; the long-shipped pacing recipe — see buildSink's `sync`
+    // docs). In clockSync mode set-timestamps stays FALSE so the shared
+    // A/V timeline survives. The 0.11 core is paid only when pacing is on.
+    const tsInput = sinkPaced
+        ? buildTsUdpInput({
+              port: udpSource.port,
+              socketPath: udpSource.socketPath,
+              stallTimeoutMs: STREAM_STALL_TIMEOUT_MS,
+              jitterMs: bufferMs,
+              setTimestamps: !preserveSourcePts,
+          })
+        : `${buildBusSrc({
+              port: udpSource.port,
+              socketPath: udpSource.socketPath,
+              stallTimeoutMs: STREAM_STALL_TIMEOUT_MS,
+          })} ! ${buildLeakyQueue(bufferMs)}`;
     const q = `queue leaky=2 max-size-time=${bufferMs * 1_000_000} max-size-buffers=0 max-size-bytes=0`;
     // Scaling policy — who resizes the picture, per sink:
     //

--- a/plugins/video-player/engine/helpers/wayland.ts
+++ b/plugins/video-player/engine/helpers/wayland.ts
@@ -19,6 +19,21 @@ import * as path from 'path';
 export const COG_POLL_INTERVAL_MS = 1000;
 
 /**
+ * Wall-clock start time of a process, from its /proc entry's mtime (set at
+ * process creation). Used to order surface creation: a cog whose process
+ * started after our pipeline did will map its surface above ours under
+ * kiosk-shell's newest-on-top stacking. Returns undefined when the process
+ * is gone (raced an exit).
+ */
+export function processStartMs(pid: number, procRoot: string = '/proc'): number | undefined {
+    try {
+        return fs.statSync(path.join(procRoot, String(pid))).mtimeMs;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * Scan /proc for a `cog` process pinned to the given DRM connector via
  * `--gapplication-app-id=local.cog.<display>`. Returns the PID of the
  * matching top-level cog process, or `undefined` if none is currently

--- a/plugins/video-player/package.json
+++ b/plugins/video-player/package.json
@@ -68,7 +68,7 @@
                 "clockSync": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Lock to the shared engine clock so video stays in sync with an audio-decoder fed from the same source — the fix for audio/video drift when one stream is split into separate video + audio playout. Turn ON here AND on the matching audio-decoder. Forces PTS-accurate playback. Leave OFF for standalone/low-latency video."
+                    "description": "EXPERIMENTAL — known issue: freezes on the first frame (source-epoch vs shared-clock mismatch, see docs/TodoNotes-video-hw-decode.md). Intended purpose: lock to the shared engine clock so video stays in lipsync with an audio-decoder fed from the same source, when one stream is split into separate video + audio playout (pairs with lipSyncMs; requires the matching audio-decoder). Leave OFF until the epoch latch is wired in — the default Honour-buffer-PTS pacing covers everything except cross-pipeline lipsync."
                 },
                 "lipSyncMs": {
                     "type": "number",

--- a/plugins/video-player/package.json
+++ b/plugins/video-player/package.json
@@ -62,8 +62,8 @@
                 },
                 "sync": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Honour buffer PTS. OFF (default): the sink presents frames as fast as they arrive — right for live SRT/RIST where latency dominates. ON: the sink waits to present each frame at its PTS — turn on for HLS so playback flows at the media's intended rate instead of speeding up on segment bursts and stalling between segments."
+                    "default": true,
+                    "description": "Smooth playback vs lowest latency. ON (default): each frame is presented at its timestamp, giving smooth, evenly-paced playback — network and decode jitter is absorbed by letting early frames wait a few tens of ms (median added latency is ~zero). OFF: every frame is shown the instant it is ready — the lowest possible latency, at the cost of visible judder under jitter. Turn OFF for ultra-low-latency chains, or as the robust fallback for degraded sources with broken PCR timing, which can stall under paced playback."
                 },
                 "clockSync": {
                     "type": "boolean",


### PR DESCRIPTION
**TL;DR** — everything here is running verified on the Pi 4 field device (`ivan-test`):

- **50 fps smooth playback** (was ~35 with stutter): paced sink default ON (`sync`), tsparse-conditional chain; latency measured ~0 at median
- **Runner CPU 0.56 → 0.26 core**: mr-tssplit fanout batching (692→39 buf/s), configurable via new `busBatchMs` (0 = ultra-low-latency)
- **renderWatch restored** with a proven fix: judges *presented* frames (sink stats), not pad arrivals
- **Two silent-failure fixes**: unconfigured-display surface never mapped; cog respawn starving video to ~1 fps
- `clockSync` marked experimental (first-frame freeze diagnosed: PES epoch vs shared clock)
- `docs/TodoNotes-video-hw-decode.md` = consolidated open items, incl. the two live-HEVC blockers found last night (**1080p SAND decode hang** — repro pair in `/data/test-media` on the field box — and the decodebin3/SAND selection wedge)

Pi 5 / Intel validation gate documented before fleet conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)