### PR TITLE
RIST input: recovered-loss visibility + relay wedge fix

### DIFF
--- a/packages/engine/src/child-process/gst-pipeline-runner.py
+++ b/packages/engine/src/child-process/gst-pipeline-runner.py
@@ -2193,13 +2193,26 @@ def _start_rist(pipe, cfg):
                 # thread-safe. A push before PLAYING / during teardown returns
                 # FLUSHING and the buffer drops — live-source semantics,
                 # exactly what udpsrc did under the CLI relay.
+                #
+                # A read error is TRANSIENT: librist deletes and recreates the
+                # flow around a link blackout (field case 2026-08-02: peer dead
+                # 832 ms → flow deleted → read returned -3), then keeps
+                # receiving into its fifo. Exiting the loop here left that fifo
+                # undrained ("Rist data out fifo queue overflow") and wedged
+                # the relay until a module restart — so warn once per error
+                # burst and keep reading.
+                err_streak = 0
                 while not _rist_stop.is_set():
                     try:
                         data = ctx.read(100)
                     except librist.RistError as e:
-                        emit_event({"event": "warning",
-                                    "message": f"librist read failed: {e}"})
-                        break
+                        err_streak += 1
+                        if err_streak == 1:
+                            emit_event({"event": "warning",
+                                        "message": f"librist read failed (retrying): {e}"})
+                        _rist_stop.wait(0.1)
+                        continue
+                    err_streak = 0
                     if not data:
                         continue
                     try:

--- a/plugins/rist-input/engine/RistInputModule.test.ts
+++ b/plugins/rist-input/engine/RistInputModule.test.ts
@@ -196,3 +196,81 @@ describe('RistInputModule rist:stats rendering', () => {
         expect(setStatusData).not.toHaveBeenCalled();
     });
 });
+
+describe('RistInputModule link health (recovered-loss storms)', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    function storm(quality: number, missing = 150, received = 850) {
+        return {
+            'receiver-stats': {
+                flowinstant: {
+                    stats: { received, missing, quality, lost: 0 },
+                    peers: [{ id: 1, stats: { avg_rtt: 210.4 } }],
+                },
+            },
+        };
+    }
+
+    function makeHealthModule() {
+        const { module, ...rest } = makeModule();
+        module.setHealth = vi.fn();
+        return { module, setHealth: module.setHealth as ReturnType<typeof vi.fn>, ...rest };
+    }
+
+    it('renders the recovered-loss rate in the flow stats', () => {
+        const { module, setStatusData } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(85, 150, 850));
+        expect(setStatusData).toHaveBeenCalledWith(
+            'stats',
+            expect.objectContaining({ loss: '15.0', rtt: '210.40' }),
+        );
+    });
+
+    it('warns only after 3 consecutive low-quality windows', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).not.toHaveBeenCalled();
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).toHaveBeenCalledWith(
+            'warning',
+            expect.stringContaining('recovering 15% packet loss'),
+        );
+    });
+
+    it('a single good window resets the warn streak (no flapping into warning)', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(100, 0));
+        module.onPluginEvent('rist:stats', storm(80));
+        module.onPluginEvent('rist:stats', storm(80));
+        expect(setHealth).not.toHaveBeenCalled();
+    });
+
+    it('clears its own warning only after 5 consecutive clean windows', () => {
+        const { module, setHealth } = makeHealthModule();
+        for (let i = 0; i < 3; i++) module.onPluginEvent('rist:stats', storm(80));
+        module.health = 'warning';
+        for (let i = 0; i < 4; i++) module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).not.toHaveBeenCalledWith('ok');
+        module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).toHaveBeenLastCalledWith('ok');
+    });
+
+    it('never clears a warning it does not own', () => {
+        const { module, setHealth } = makeHealthModule();
+        module.health = 'warning'; // someone else's warning, linkWarnActive false
+        for (let i = 0; i < 6; i++) module.onPluginEvent('rist:stats', storm(100, 0));
+        expect(setHealth).not.toHaveBeenCalled();
+    });
+
+    it('mid-band quality (85–95) keeps an active warning latched', () => {
+        const { module, setHealth } = makeHealthModule();
+        for (let i = 0; i < 3; i++) module.onPluginEvent('rist:stats', storm(80));
+        module.health = 'warning';
+        setHealth.mockClear();
+        for (let i = 0; i < 10; i++) module.onPluginEvent('rist:stats', storm(90, 50, 950));
+        expect(setHealth).not.toHaveBeenCalledWith('ok');
+    });
+});

--- a/plugins/rist-input/engine/RistInputModule.ts
+++ b/plugins/rist-input/engine/RistInputModule.ts
@@ -30,8 +30,32 @@ const RIST_APPSRC = 'ristsrc';
  * kept for full feature support: per-link weight, cname, main/advanced
  * profiles, encryption.
  */
+/**
+ * Link-health hysteresis on librist's quality metric (100 = no loss). RIST
+ * recovers lost packets via retransmission, so a badly degraded link can carry
+ * a perfect stream — invisible unless surfaced here. Field case, 2026-08-02:
+ * production-hours loss storms of 10–20 % (all recovered, `lost=0`) were the
+ * prime suspect behind intermittent video delivery dips, yet every ad-hoc
+ * link check came back clean because only unrecovered loss is observable.
+ * Warn after WARN_STREAK consecutive low-quality stats windows; clear only
+ * after CLEAR_STREAK clean ones so a flapping link doesn't flap the health.
+ */
+const QUALITY_WARN = 85;
+const QUALITY_CLEAR = 95;
+const WARN_STREAK = 3;
+const CLEAR_STREAK = 5;
+
 export class RistInputModule extends GstPluginBase {
+    private linkWarnActive = false;
+    private lowStreak = 0;
+    private okStreak = 0;
+
     async onStart(): Promise<void> {
+        // A rebuilt receiver re-measures from scratch — stale hysteresis must
+        // not suppress or fake a link warning.
+        this.linkWarnActive = false;
+        this.lowStreak = 0;
+        this.okStreak = 0;
         // Assign the bus output channel before buildPipeline reads it back.
         // The port is the channel identity (busout_<port> tee under unixfd).
         if (this.services?.mediaRouter) {
@@ -102,19 +126,34 @@ export class RistInputModule extends GstPluginBase {
 
         const s = flow.stats;
 
-        // Flow-level stats (aggregate across all peers)
-        this.setStatusData('stats', {
-            received: Number(s.received ?? 0),
-            dropped: Number(s.dropped_late ?? 0),
-            recovered: Number(s.recovered_total ?? 0),
-            lost: Number(s.lost ?? 0),
-            rtt: '—',
-        });
+        // Recovered-loss rate this stats window: what fraction of the wire
+        // went missing before retransmission repaired it. `lost` only counts
+        // UNrecovered packets, so this is the metric that exposes a degraded
+        // link that still delivers a perfect stream.
+        const missing = Number(s.missing ?? 0);
+        const received = Number(s.received ?? 0);
+        const lossPct = received + missing > 0 ? (100 * missing) / (received + missing) : 0;
 
-        // Per-peer stats and dynamic sections
         const peers = flow.peers as
             | Array<{ id?: number; cname?: string; stats?: Record<string, unknown> }>
             | undefined;
+        const firstPeer = peers?.[0]?.stats;
+        const rtt =
+            typeof firstPeer?.avg_rtt === 'number'
+                ? (firstPeer.avg_rtt as number).toFixed(2)
+                : String(firstPeer?.rtt ?? '—');
+
+        // Flow-level stats (aggregate across all peers)
+        this.setStatusData('stats', {
+            received,
+            dropped: Number(s.dropped_late ?? 0),
+            recovered: Number(s.recovered_total ?? 0),
+            loss: lossPct.toFixed(1),
+            lost: Number(s.lost ?? 0),
+            rtt,
+        });
+
+        // Per-peer stats and dynamic sections
         if (peers && peers.length > 0) {
             const peerFields = [
                 { key: 'quality', label: 'Quality', unit: '%' },
@@ -153,24 +192,10 @@ export class RistInputModule extends GstPluginBase {
                     ];
                 }
             }
-
-            // Use first peer's RTT for the flow-level display
-            const firstPeer = peers[0]?.stats;
-            if (firstPeer) {
-                this.setStatusData('stats', {
-                    received: Number(s.received ?? 0),
-                    dropped: Number(s.dropped_late ?? 0),
-                    recovered: Number(s.recovered_total ?? 0),
-                    lost: Number(s.lost ?? 0),
-                    rtt:
-                        typeof firstPeer.avg_rtt === 'number'
-                            ? `${(firstPeer.avg_rtt as number).toFixed(2)}`
-                            : String(firstPeer.rtt ?? '—'),
-                });
-            }
         }
 
         const quality = Number(s.quality ?? 0);
+        this.applyLinkHealth(quality, lossPct, rtt);
         this.setBadge('quality', {
             icon: 'signal',
             text: `${quality}%`,
@@ -184,6 +209,34 @@ export class RistInputModule extends GstPluginBase {
             text: `${peerCount}`,
             color: peerCount > 0 ? '#10b981' : '#6b7280',
         });
+    }
+
+    /** See the hysteresis constants above for why this exists. */
+    private applyLinkHealth(quality: number, lossPct: number, rtt: string): void {
+        if (quality < QUALITY_WARN) {
+            this.lowStreak++;
+            this.okStreak = 0;
+        } else if (quality >= QUALITY_CLEAR) {
+            this.okStreak++;
+            this.lowStreak = 0;
+        } else {
+            // In-between band: neither degrades further nor proves recovery.
+            this.lowStreak = 0;
+            this.okStreak = 0;
+        }
+        if (this.lowStreak >= WARN_STREAK) {
+            this.linkWarnActive = true;
+            this.setHealth(
+                'warning',
+                `RIST link degraded — recovering ${lossPct.toFixed(0)}% packet loss ` +
+                    `(RTT ${rtt} ms); stream still intact`,
+            );
+        } else if (this.okStreak >= CLEAR_STREAK && this.linkWarnActive) {
+            // Only clear health WE degraded — never stomp a warning another
+            // path owns.
+            if (this.health === 'warning') this.setHealth('ok');
+            this.linkWarnActive = false;
+        }
     }
 }
 

--- a/plugins/rist-input/package.json
+++ b/plugins/rist-input/package.json
@@ -2,7 +2,7 @@
     "name": "@media-router/plugin-rist-input",
     "version": "2.0.0",
     "private": true,
-    "description": "RIST input \u2014 receives MPEG-TS stream over RIST protocol with bonding support",
+    "description": "RIST input — receives MPEG-TS stream over RIST protocol with bonding support",
     "mediaRouter": {
         "pluginId": "rist-input",
         "displayName": "RIST Input",
@@ -152,6 +152,11 @@
                     {
                         "key": "recovered",
                         "label": "Recovered"
+                    },
+                    {
+                        "key": "loss",
+                        "label": "Loss (recovered)",
+                        "unit": "%"
                     },
                     {
                         "key": "lost",


### PR DESCRIPTION
TL;DR — two field-driven RIST fixes (Pi 4, live OCC feed, 2026-08-02):

- **Relay wedge fix**: the librist read loop exited permanently on the first read error. A 832 ms WAN blackout makes librist delete+recreate its flow, the read raises `-3` once, and the relay then sat receiving into an undrained fifo ("Rist data out fifo queue overflow") until a module restart — downstream ts-splitter starved with "no input data". The loop now retries through transient errors.
- **Recovered-loss visibility**: production-hours loss storms (10–20% missing, all recovered by retransmission, `lost=0`) were invisible — every ad-hoc link check came back clean because only *unrecovered* loss is observable. New "Loss (recovered)" % in Live Stats + a hysteresis health warning (quality <85 for 3 stats windows → "RIST link degraded — recovering N% packet loss; stream still intact", clears after 5 clean windows).

2018 tests passing across 146 files (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)